### PR TITLE
Fix player input focus loss

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -51,7 +51,7 @@ const PlayerSetupScreen = () => {
               showsVerticalScrollIndicator={false}
             >
               {players.map((player, index) => (
-                <View key={`${index}-${player}`} style={styles.playerRow}>
+                <View key={`player-${index}`} style={styles.playerRow}>
                   <TextInput
                     value={player}
                     onChangeText={(text) => updatePlayer(index, text)}


### PR DESCRIPTION
## Summary
- use stable keys for player rows to prevent text inputs from remounting while typing

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c997fdc0ac832dbd67c3b9d1c49fe7