### PR TITLE
Add bilingual gameplay support

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 
 import { GameProvider } from '@/context/GameContext';
+import { LocalizationProvider, useLocalization } from '@/context/LocalizationContext';
 
 export const unstable_settings = {
   initialRouteName: 'index',
@@ -8,12 +9,22 @@ export const unstable_settings = {
 
 export default function RootLayout() {
   return (
-    <GameProvider>
-      <Stack>
-        <Stack.Screen name="index" options={{ headerShown: false }} />
-        <Stack.Screen name="modes" options={{ title: 'Game Modes' }} />
-        <Stack.Screen name="game" options={{ title: 'Rabatize' }} />
-      </Stack>
-    </GameProvider>
+    <LocalizationProvider>
+      <GameProvider>
+        <LocalizedStack />
+      </GameProvider>
+    </LocalizationProvider>
   );
 }
+
+const LocalizedStack = () => {
+  const { t } = useLocalization();
+
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen name="modes" options={{ title: t('navigation.modes') }} />
+      <Stack.Screen name="game" options={{ title: t('navigation.game') }} />
+    </Stack>
+  );
+};

--- a/apps/mobile/app/game.tsx
+++ b/apps/mobile/app/game.tsx
@@ -3,15 +3,18 @@ import { useEffect, useMemo, useState } from 'react';
 import { Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 
 import { useGame } from '@/context/GameContext';
-import { gameModes } from '@/constants/gameModes';
+import { useLocalization } from '@/context/LocalizationContext';
+import { gameModes, getGameModeCopy } from '@/constants/gameModes';
 import { compileRule, type CompiledRule } from '@/constants/rules';
 
 const GameScreen = () => {
   const { activePlayers, selectedModeId, maxDrinks } = useGame();
   const router = useRouter();
+  const { t, language } = useLocalization();
   const [currentRule, setCurrentRule] = useState<CompiledRule | null>(null);
 
   const mode = useMemo(() => gameModes.find((item) => item.id === selectedModeId), [selectedModeId]);
+  const modeCopy = useMemo(() => (mode ? getGameModeCopy(mode, language) : null), [language, mode]);
 
   useEffect(() => {
     if (activePlayers.length < 2) {
@@ -30,12 +33,12 @@ const GameScreen = () => {
       return;
     }
 
-    setCurrentRule(compileRule(activePlayers, maxDrinks, selectedModeId));
-  }, [activePlayers, maxDrinks, selectedModeId]);
+    setCurrentRule(compileRule(activePlayers, maxDrinks, selectedModeId, language));
+  }, [activePlayers, language, maxDrinks, selectedModeId]);
 
   const handleNextCard = () => {
     if (selectedModeId) {
-      setCurrentRule(compileRule(activePlayers, maxDrinks, selectedModeId));
+      setCurrentRule(compileRule(activePlayers, maxDrinks, selectedModeId, language));
     }
   };
 
@@ -47,8 +50,8 @@ const GameScreen = () => {
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
         <View style={styles.header}>
-          <Text style={styles.modeName}>{mode?.name ?? 'Rabatize'}</Text>
-          <Text style={styles.modeSubtitle}>Up to {maxDrinks} drinks per card</Text>
+          <Text style={styles.modeName}>{modeCopy?.name ?? t('home.title')}</Text>
+          <Text style={styles.modeSubtitle}>{t('game.maxDrinks', { count: maxDrinks })}</Text>
         </View>
 
         <View style={styles.card}>
@@ -58,7 +61,7 @@ const GameScreen = () => {
                 <Text style={styles.cardTitle}>{currentRule.title}</Text>
                 <View style={styles.drinksBadge}>
                   <Text style={styles.drinksBadgeText}>{currentRule.drinks}</Text>
-                  <Text style={styles.drinksBadgeLabel}>drinks</Text>
+                  <Text style={styles.drinksBadgeLabel}>{t('game.drinksLabel')}</Text>
                 </View>
               </View>
 
@@ -75,18 +78,16 @@ const GameScreen = () => {
               <Text style={styles.cardBody}>{currentRule.text}</Text>
             </>
           ) : (
-            <Text style={styles.cardBody}>
-              Add more players or adjust the mode to generate a rule.
-            </Text>
+            <Text style={styles.cardBody}>{t('game.emptyState')}</Text>
           )}
         </View>
 
         <View style={styles.actions}>
           <Pressable style={styles.primaryButton} onPress={handleNextCard}>
-            <Text style={styles.primaryButtonText}>Next card</Text>
+            <Text style={styles.primaryButtonText}>{t('game.nextCard')}</Text>
           </Pressable>
           <Pressable style={styles.secondaryButton} onPress={handleAdjustSettings}>
-            <Text style={styles.secondaryButtonText}>Adjust settings</Text>
+            <Text style={styles.secondaryButtonText}>{t('game.adjustSettings')}</Text>
           </Pressable>
         </View>
       </View>

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -14,10 +14,12 @@ import {
 } from 'react-native';
 
 import { useGame } from '@/context/GameContext';
+import { useLocalization } from '@/context/LocalizationContext';
 
 const PlayerSetupScreen = () => {
   const { players, activePlayers, updatePlayer, addPlayer, removePlayer, resetMode } = useGame();
   const router = useRouter();
+  const { t, language, toggleLanguage } = useLocalization();
 
   useEffect(() => {
     resetMode();
@@ -31,6 +33,10 @@ const PlayerSetupScreen = () => {
     }
   };
 
+  const nextLanguage = language === 'en' ? 'fr' : 'en';
+  const nextLanguageName = t(nextLanguage === 'en' ? 'language.en' : 'language.fr');
+  const flag = language === 'fr' ? '🇫🇷' : '🇬🇧';
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <StatusBar style="light" />
@@ -39,9 +45,21 @@ const PlayerSetupScreen = () => {
         style={styles.flex}
       >
         <View style={styles.container}>
+          <View style={styles.languageRow}>
+            <Pressable
+              accessibilityHint={t('home.languageToggle.hint', { language: nextLanguageName })}
+              accessibilityLabel={t('home.languageToggle.accessibility')}
+              accessibilityRole="button"
+              hitSlop={10}
+              onPress={toggleLanguage}
+              style={styles.languageToggle}
+            >
+              <Text style={styles.languageFlag}>{flag}</Text>
+            </Pressable>
+          </View>
           <View style={styles.header}>
-            <Text style={styles.title}>Rabatize</Text>
-            <Text style={styles.subtitle}>Gather the crew and set the stage.</Text>
+            <Text style={styles.title}>{t('home.title')}</Text>
+            <Text style={styles.subtitle}>{t('home.subtitle')}</Text>
           </View>
 
           <View style={styles.playerSection}>
@@ -55,13 +73,13 @@ const PlayerSetupScreen = () => {
                   <TextInput
                     value={player}
                     onChangeText={(text) => updatePlayer(index, text)}
-                    placeholder={`Player ${index + 1}`}
+                    placeholder={t('home.playerPlaceholder', { index: index + 1 })}
                     placeholderTextColor="#777"
                     style={styles.playerInput}
                   />
                   {players.length > 1 && (
                     <Pressable
-                      accessibilityLabel={`Remove player ${index + 1}`}
+                      accessibilityLabel={t('home.removePlayer', { index: index + 1 })}
                       onPress={() => removePlayer(index)}
                       style={styles.removeButton}
                     >
@@ -72,7 +90,7 @@ const PlayerSetupScreen = () => {
               ))}
 
               <Pressable style={styles.addButton} onPress={addPlayer}>
-                <Text style={styles.addButtonText}>+ Add player</Text>
+                <Text style={styles.addButtonText}>{t('home.addPlayer')}</Text>
               </Pressable>
             </ScrollView>
           </View>
@@ -82,10 +100,8 @@ const PlayerSetupScreen = () => {
             style={[styles.startButton, !canStart && styles.startButtonDisabled]}
             disabled={!canStart}
           >
-            <Text style={styles.startButtonText}>Choose a mode</Text>
-            {!canStart && (
-              <Text style={styles.helperText}>Add at least two players to begin.</Text>
-            )}
+            <Text style={styles.startButtonText}>{t('home.chooseMode')}</Text>
+            {!canStart && <Text style={styles.helperText}>{t('home.helperAddPlayers')}</Text>}
           </Pressable>
         </View>
       </KeyboardAvoidingView>
@@ -109,6 +125,20 @@ const styles = StyleSheet.create({
   },
   header: {
     gap: 8,
+  },
+  languageRow: {
+    alignItems: 'flex-start',
+    marginBottom: 16,
+  },
+  languageToggle: {
+    alignSelf: 'flex-start',
+    backgroundColor: 'rgba(148, 163, 184, 0.2)',
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  languageFlag: {
+    fontSize: 18,
   },
   title: {
     fontSize: 36,

--- a/apps/mobile/app/modes.tsx
+++ b/apps/mobile/app/modes.tsx
@@ -3,7 +3,8 @@ import { useState } from 'react';
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { useGame } from '@/context/GameContext';
-import { gameModes } from '@/constants/gameModes';
+import { useLocalization } from '@/context/LocalizationContext';
+import { gameModes, getGameModeCopy } from '@/constants/gameModes';
 
 const ModeSelectionScreen = () => {
   const {
@@ -15,6 +16,7 @@ const ModeSelectionScreen = () => {
     decreaseMaxDrinks,
   } = useGame();
   const router = useRouter();
+  const { t, language } = useLocalization();
   const [expandedModeId, setExpandedModeId] = useState<string | null>(selectedModeId);
 
   const canStart = Boolean(selectedModeId) && activePlayers.length >= 2;
@@ -28,13 +30,14 @@ const ModeSelectionScreen = () => {
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
-        <Text style={styles.title}>Select a game mode</Text>
-        <Text style={styles.subtitle}>Each mode changes the rhythm of the night.</Text>
+        <Text style={styles.title}>{t('modes.title')}</Text>
+        <Text style={styles.subtitle}>{t('modes.subtitle')}</Text>
 
         <ScrollView style={styles.modeList} contentContainerStyle={styles.modeListContent}>
           {gameModes.map((mode) => {
             const selected = mode.id === selectedModeId;
             const expanded = mode.id === expandedModeId || selected;
+            const copy = getGameModeCopy(mode, language);
 
             return (
               <Pressable
@@ -45,9 +48,9 @@ const ModeSelectionScreen = () => {
                 }}
                 style={[styles.modeCard, selected && styles.modeCardSelected]}
               >
-                <Text style={styles.modeTitle}>{mode.name}</Text>
-                <Text style={styles.modeTagline}>{mode.tagline}</Text>
-                {expanded && <Text style={styles.modeDescription}>{mode.description}</Text>}
+                <Text style={styles.modeTitle}>{copy.name}</Text>
+                <Text style={styles.modeTagline}>{copy.tagline}</Text>
+                {expanded && <Text style={styles.modeDescription}>{copy.description}</Text>}
               </Pressable>
             );
           })}
@@ -55,8 +58,8 @@ const ModeSelectionScreen = () => {
 
         <View style={styles.settingsPanel}>
           <View>
-            <Text style={styles.settingsTitle}>Maximum drinks per card</Text>
-            <Text style={styles.settingsSubtitle}>Tune the intensity before you start.</Text>
+            <Text style={styles.settingsTitle}>{t('modes.settingsTitle')}</Text>
+            <Text style={styles.settingsSubtitle}>{t('modes.settingsSubtitle')}</Text>
           </View>
           <View style={styles.stepper}>
             <Pressable style={styles.stepperButton} onPress={decreaseMaxDrinks}>
@@ -74,9 +77,9 @@ const ModeSelectionScreen = () => {
           style={[styles.startButton, !canStart && styles.startButtonDisabled]}
           disabled={!canStart}
         >
-          <Text style={styles.startButtonText}>Start the game</Text>
+          <Text style={styles.startButtonText}>{t('modes.startGame')}</Text>
           {!canStart && (
-            <Text style={styles.helperText}>Select a mode and make sure at least two players are ready.</Text>
+            <Text style={styles.helperText}>{t('modes.helper')}</Text>
           )}
         </Pressable>
       </View>

--- a/apps/mobile/constants/gameModes.ts
+++ b/apps/mobile/constants/gameModes.ts
@@ -1,30 +1,69 @@
-export type GameMode = {
-  id: string;
+import { fallbackLanguage, type Language } from './i18n';
+
+export type GameModeCopy = {
   name: string;
   tagline: string;
   description: string;
 };
 
+export type GameMode = {
+  id: string;
+  translations: Record<Language, GameModeCopy>;
+};
+
 export const gameModes: GameMode[] = [
   {
     id: 'classic',
-    name: 'Classic Rabatize',
-    tagline: 'Balanced mix of group prompts and quick dares.',
-    description:
-      'The classic experience. Expect social challenges, rhythm games, and cheers that make everyone feel part of the crew.',
+    translations: {
+      en: {
+        name: 'Classic Rabatize',
+        tagline: 'Balanced mix of group prompts and quick dares.',
+        description:
+          'The classic experience. Expect social challenges, rhythm games, and cheers that make everyone feel part of the crew.',
+      },
+      fr: {
+        name: 'Rabatize Classique',
+        tagline: 'Mélange équilibré de défis de groupe et de gages rapides.',
+        description:
+          'L’expérience classique. Attends-toi à des défis sociaux, des jeux de rythme et des toasts qui mettent tout le monde dans l’ambiance.',
+      },
+    },
   },
   {
     id: 'storyteller',
-    name: 'Storyteller',
-    tagline: 'Spin tales, weave lies, and toast to the best improv.',
-    description:
-      'Every card nudges the group to share a story or improvise a hilarious moment. Perfect for players who love tall tales.',
+    translations: {
+      en: {
+        name: 'Storyteller',
+        tagline: 'Spin tales, weave lies, and toast to the best improv.',
+        description:
+          'Every card nudges the group to share a story or improvise a hilarious moment. Perfect for players who love tall tales.',
+      },
+      fr: {
+        name: 'Conteur',
+        tagline: 'Raconte des histoires, improvise et trinque pour la meilleure impro.',
+        description:
+          'Chaque carte pousse le groupe à partager une histoire ou à improviser un moment hilarant. Parfait pour ceux qui adorent les récits.',
+      },
+    },
   },
   {
     id: 'chaos',
-    name: 'Chaos Mode',
-    tagline: 'Fast-paced twists with plenty of group participation.',
-    description:
-      'Expect the unexpected: sudden challenges, partner swaps, and cheers that keep everyone guessing what comes next.',
+    translations: {
+      en: {
+        name: 'Chaos Mode',
+        tagline: 'Fast-paced twists with plenty of group participation.',
+        description:
+          'Expect the unexpected: sudden challenges, partner swaps, and cheers that keep everyone guessing what comes next.',
+      },
+      fr: {
+        name: 'Mode Chaos',
+        tagline: 'Des rebondissements rapides avec beaucoup de participation.',
+        description:
+          'Attends-toi à l’imprévu : défis éclairs, échanges de partenaires et toasts qui surprennent à chaque carte.',
+      },
+    },
   },
 ];
+
+export const getGameModeCopy = (mode: GameMode, language: Language): GameModeCopy =>
+  mode.translations[language] ?? mode.translations[fallbackLanguage];

--- a/apps/mobile/constants/i18n.ts
+++ b/apps/mobile/constants/i18n.ts
@@ -1,0 +1,67 @@
+export const supportedLanguages = ['en', 'fr'] as const;
+
+export type Language = (typeof supportedLanguages)[number];
+
+export const fallbackLanguage: Language = 'en';
+
+export const translations = {
+  en: {
+    'language.en': 'English',
+    'language.fr': 'French',
+    'home.title': 'Rabatize',
+    'home.subtitle': 'Gather the crew and set the stage.',
+    'home.playerPlaceholder': 'Player {{index}}',
+    'home.addPlayer': '+ Add player',
+    'home.chooseMode': 'Choose a mode',
+    'home.helperAddPlayers': 'Add at least two players to begin.',
+    'home.removePlayer': 'Remove player {{index}}',
+    'home.languageToggle.accessibility': 'Change language',
+    'home.languageToggle.hint': 'Switch to {{language}}',
+    'modes.title': 'Select a game mode',
+    'modes.subtitle': 'Each mode changes the rhythm of the night.',
+    'modes.settingsTitle': 'Maximum drinks per card',
+    'modes.settingsSubtitle': 'Tune the intensity before you start.',
+    'modes.startGame': 'Start the game',
+    'modes.helper': 'Select a mode and make sure at least two players are ready.',
+    'game.maxDrinks': 'Up to {{count}} drinks per card',
+    'game.emptyState': 'Add more players or adjust the mode to generate a rule.',
+    'game.nextCard': 'Next card',
+    'game.adjustSettings': 'Adjust settings',
+    'game.drinksLabel': 'drinks',
+    'navigation.modes': 'Game Modes',
+    'navigation.game': 'Rabatize',
+  },
+  fr: {
+    'language.en': 'Anglais',
+    'language.fr': 'Français',
+    'home.title': 'Rabatize',
+    'home.subtitle': 'Rassemble la team et mets l’ambiance.',
+    'home.playerPlaceholder': 'Joueur {{index}}',
+    'home.addPlayer': '+ Ajouter un joueur',
+    'home.chooseMode': 'Choisir un mode',
+    'home.helperAddPlayers': 'Ajoute au moins deux joueurs pour commencer.',
+    'home.removePlayer': 'Retirer le joueur {{index}}',
+    'home.languageToggle.accessibility': 'Changer de langue',
+    'home.languageToggle.hint': 'Basculer vers {{language}}',
+    'modes.title': 'Choisis un mode de jeu',
+    'modes.subtitle': 'Chaque mode change le rythme de la soirée.',
+    'modes.settingsTitle': 'Nombre max de gorgées par carte',
+    'modes.settingsSubtitle': 'Ajuste l’intensité avant de commencer.',
+    'modes.startGame': 'Lancer la partie',
+    'modes.helper': 'Choisis un mode et assure-toi qu’au moins deux joueurs sont prêts.',
+    'game.maxDrinks': 'Jusqu’à {{count}} gorgées par carte',
+    'game.emptyState': 'Ajoute des joueurs ou ajuste le mode pour générer une règle.',
+    'game.nextCard': 'Carte suivante',
+    'game.adjustSettings': 'Ajuster les paramètres',
+    'game.drinksLabel': 'gorgées',
+    'navigation.modes': 'Modes de jeu',
+    'navigation.game': 'Partie',
+  },
+} as const satisfies Record<Language, Record<string, string>>;
+
+export type TranslationKey = keyof (typeof translations)[Language];
+
+export type TranslationParams = Record<string, string | number>;
+
+export const isSupportedLanguage = (value: string): value is Language =>
+  supportedLanguages.some((language) => language === value);

--- a/apps/mobile/constants/rules.ts
+++ b/apps/mobile/constants/rules.ts
@@ -1,9 +1,13 @@
+import { fallbackLanguage, type Language } from './i18n';
+
 export type RuleTemplate = {
   id: string;
   title: string;
   prompt: string;
   participants: number;
   modeIds: string[];
+  language: Language;
+  translationMap: Partial<Record<Language, string>>;
 };
 
 export type CompiledRule = {
@@ -12,67 +16,162 @@ export type CompiledRule = {
   text: string;
   drinks: number;
   players: string[];
+  language: Language;
+  translationMap: Partial<Record<Language, string>>;
 };
 
 const ruleTemplates: RuleTemplate[] = [
   {
     id: 'toast-master',
     title: 'Toast Master',
+    prompt: '{{player_1}} raises a toast and gives out {{drinks}} drinks to share.',
     participants: 1,
     modeIds: ['classic', 'storyteller', 'chaos'],
-    prompt: '{{player_1}} raises a toast and gives out {{drinks}} drinks to share.',
+    language: 'en',
+    translationMap: { en: 'toast-master', fr: 'toast-master-fr' },
+  },
+  {
+    id: 'toast-master-fr',
+    title: 'Maître du toast',
+    prompt: '{{player_1}} porte un toast et distribue {{drinks}} gorgées à partager.',
+    participants: 1,
+    modeIds: ['classic', 'storyteller', 'chaos'],
+    language: 'fr',
+    translationMap: { en: 'toast-master', fr: 'toast-master-fr' },
   },
   {
     id: 'story-swap',
     title: 'Story Swap',
-    participants: 2,
-    modeIds: ['classic', 'storyteller'],
     prompt:
       '{{player_1}} tells a quick tale about {{player_2}}. If {{player_2}} laughs, they hand out {{drinks}} drinks; otherwise {{player_1}} drinks them.',
+    participants: 2,
+    modeIds: ['classic', 'storyteller'],
+    language: 'en',
+    translationMap: { en: 'story-swap', fr: 'story-swap-fr' },
+  },
+  {
+    id: 'story-swap-fr',
+    title: 'Échange d\'histoires',
+    prompt:
+      '{{player_1}} raconte une histoire rapide sur {{player_2}}. Si {{player_2}} rit, iel distribue {{drinks}} gorgées ; sinon {{player_1}} les boit.',
+    participants: 2,
+    modeIds: ['classic', 'storyteller'],
+    language: 'fr',
+    translationMap: { en: 'story-swap', fr: 'story-swap-fr' },
   },
   {
     id: 'rabatize-chant',
     title: 'Rabatize Chant',
-    participants: 1,
-    modeIds: ['classic', 'chaos'],
     prompt:
       'Everyone chants "Rabatize" while {{player_1}} counts down from five. Anyone who breaks rhythm drinks {{drinks}}.',
+    participants: 1,
+    modeIds: ['classic', 'chaos'],
+    language: 'en',
+    translationMap: { en: 'rabatize-chant', fr: 'rabatize-chant-fr' },
+  },
+  {
+    id: 'rabatize-chant-fr',
+    title: 'Chant Rabatize',
+    prompt:
+      'Tout le monde scande "Rabatize" pendant que {{player_1}} compte à rebours depuis cinq. Ceux qui cassent le rythme boivent {{drinks}}.',
+    participants: 1,
+    modeIds: ['classic', 'chaos'],
+    language: 'fr',
+    translationMap: { en: 'rabatize-chant', fr: 'rabatize-chant-fr' },
   },
   {
     id: 'synchronized-clap',
     title: 'Synchronized Clap',
+    prompt: '{{player_1}} and {{player_2}} perform a synchronized clap. If they miss, both drink {{drinks}}.',
     participants: 2,
     modeIds: ['chaos'],
-    prompt: '{{player_1}} and {{player_2}} perform a synchronized clap. If they miss, both drink {{drinks}}.',
+    language: 'en',
+    translationMap: { en: 'synchronized-clap', fr: 'synchronized-clap-fr' },
+  },
+  {
+    id: 'synchronized-clap-fr',
+    title: 'Claque synchronisée',
+    prompt:
+      '{{player_1}} et {{player_2}} tapent dans leurs mains en même temps. S’ils ratent, les deux boivent {{drinks}}.',
+    participants: 2,
+    modeIds: ['chaos'],
+    language: 'fr',
+    translationMap: { en: 'synchronized-clap', fr: 'synchronized-clap-fr' },
   },
   {
     id: 'story-relay',
     title: 'Story Relay',
-    participants: 3,
-    modeIds: ['storyteller'],
     prompt:
       '{{player_1}} starts a story, {{player_2}} continues it, and {{player_3}} ends it. The trio hands out {{drinks}} drinks if the table applauds.',
+    participants: 3,
+    modeIds: ['storyteller'],
+    language: 'en',
+    translationMap: { en: 'story-relay', fr: 'story-relay-fr' },
+  },
+  {
+    id: 'story-relay-fr',
+    title: 'Relais d\'histoires',
+    prompt:
+      '{{player_1}} commence une histoire, {{player_2}} la continue et {{player_3}} la conclut. Le trio distribue {{drinks}} gorgées si la table applaudit.',
+    participants: 3,
+    modeIds: ['storyteller'],
+    language: 'fr',
+    translationMap: { en: 'story-relay', fr: 'story-relay-fr' },
   },
   {
     id: 'call-out',
     title: 'Call Out',
+    prompt: 'Anyone who has toasted with {{player_1}} tonight drinks {{drinks}}.',
     participants: 1,
     modeIds: ['classic', 'chaos'],
-    prompt: 'Anyone who has toasted with {{player_1}} tonight drinks {{drinks}}.',
+    language: 'en',
+    translationMap: { en: 'call-out', fr: 'call-out-fr' },
+  },
+  {
+    id: 'call-out-fr',
+    title: 'Appel ciblé',
+    prompt: 'Tous ceux qui ont trinqué avec {{player_1}} ce soir boivent {{drinks}}.',
+    participants: 1,
+    modeIds: ['classic', 'chaos'],
+    language: 'fr',
+    translationMap: { en: 'call-out', fr: 'call-out-fr' },
   },
   {
     id: 'spotlight-word',
     title: 'Spotlight Word',
+    prompt: '{{player_1}} picks a word. Everyone tells a mini-story using it or drinks {{drinks}}.',
     participants: 1,
     modeIds: ['storyteller', 'classic'],
-    prompt: '{{player_1}} picks a word. Everyone tells a mini-story using it or drinks {{drinks}}.',
+    language: 'en',
+    translationMap: { en: 'spotlight-word', fr: 'spotlight-word-fr' },
+  },
+  {
+    id: 'spotlight-word-fr',
+    title: 'Mot vedette',
+    prompt:
+      '{{player_1}} choisit un mot. Tout le monde raconte une mini-histoire qui l’utilise ou boit {{drinks}}.',
+    participants: 1,
+    modeIds: ['storyteller', 'classic'],
+    language: 'fr',
+    translationMap: { en: 'spotlight-word', fr: 'spotlight-word-fr' },
   },
   {
     id: 'seat-swap',
     title: 'Seat Swap',
+    prompt: '{{player_1}} swaps seats with {{player_2}}. The last to sit drinks {{drinks}}.',
     participants: 2,
     modeIds: ['classic', 'chaos'],
-    prompt: '{{player_1}} swaps seats with {{player_2}}. The last to sit drinks {{drinks}}.',
+    language: 'en',
+    translationMap: { en: 'seat-swap', fr: 'seat-swap-fr' },
+  },
+  {
+    id: 'seat-swap-fr',
+    title: 'Échange de places',
+    prompt: '{{player_1}} échange sa place avec {{player_2}}. Le dernier à s’asseoir boit {{drinks}}.',
+    participants: 2,
+    modeIds: ['classic', 'chaos'],
+    language: 'fr',
+    translationMap: { en: 'seat-swap', fr: 'seat-swap-fr' },
   },
 ];
 
@@ -99,18 +198,36 @@ export const compileRule = (
   players: string[],
   maxDrinks: number,
   modeId: string | null,
+  language: Language,
 ): CompiledRule | null => {
   if (players.length === 0) {
     return null;
   }
 
-  const applicableRules = ruleTemplates.filter(
-    (rule) => (!modeId || rule.modeIds.includes(modeId)) && players.length >= rule.participants,
-  );
+  const languagesToTry: Language[] =
+    language === fallbackLanguage ? [language] : [language, fallbackLanguage];
 
-  const fallbackRules = ruleTemplates.filter((rule) => players.length >= rule.participants);
+  let template: RuleTemplate | null = null;
 
-  const template = pickRandom(applicableRules) ?? pickRandom(fallbackRules);
+  for (const currentLanguage of languagesToTry) {
+    const languageRules = ruleTemplates.filter((rule) => rule.language === currentLanguage);
+
+    if (languageRules.length === 0) {
+      continue;
+    }
+
+    const applicableRules = languageRules.filter(
+      (rule) => (!modeId || rule.modeIds.includes(modeId)) && players.length >= rule.participants,
+    );
+
+    const fallbackRules = languageRules.filter((rule) => players.length >= rule.participants);
+
+    template = pickRandom(applicableRules) ?? pickRandom(fallbackRules);
+
+    if (template) {
+      break;
+    }
+  }
 
   if (!template) {
     return null;
@@ -126,11 +243,18 @@ export const compileRule = (
     })
     .replace(drinksToken, String(drinks));
 
+  const translationMap = {
+    ...template.translationMap,
+    [template.language]: template.id,
+  };
+
   return {
     id: template.id,
     title: template.title,
     text,
     drinks,
     players: selectedPlayers,
+    language: template.language,
+    translationMap,
   };
 };

--- a/apps/mobile/context/LocalizationContext.tsx
+++ b/apps/mobile/context/LocalizationContext.tsx
@@ -1,0 +1,144 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import { NativeModules, Platform } from 'react-native';
+
+import {
+  fallbackLanguage,
+  isSupportedLanguage,
+  translations,
+  type Language,
+  type TranslationKey,
+  type TranslationParams,
+} from '@/constants/i18n';
+
+const extractLanguageCode = (value?: string | null): Language | null => {
+  if (!value) {
+    return null;
+  }
+
+  const languageCode = value.split(/[-_]/)[0]?.toLowerCase();
+
+  if (languageCode && isSupportedLanguage(languageCode)) {
+    return languageCode;
+  }
+
+  return null;
+};
+
+const getLanguageFromNativeModules = (): Language | null => {
+  try {
+    if (Platform.OS === 'ios') {
+      const settings = NativeModules?.SettingsManager?.settings;
+      const locale =
+        (Array.isArray(settings?.AppleLanguages) ? settings?.AppleLanguages[0] : null) ??
+        settings?.AppleLocale;
+
+      return extractLanguageCode(locale);
+    }
+
+    if (Platform.OS === 'android') {
+      const locale = NativeModules?.I18nManager?.localeIdentifier;
+      return extractLanguageCode(locale);
+    }
+  } catch (error) {
+    // Ignore errors from native lookups.
+  }
+
+  return null;
+};
+
+const detectInitialLanguage = (): Language => {
+  const nativeLanguage = getLanguageFromNativeModules();
+
+  if (nativeLanguage) {
+    return nativeLanguage;
+  }
+
+  const globalNavigator =
+    typeof globalThis !== 'undefined' && typeof (globalThis as { navigator?: unknown }).navigator !== 'undefined'
+      ? (globalThis as { navigator?: { language?: string } }).navigator
+      : null;
+  const navigatorLanguage = globalNavigator?.language
+    ? extractLanguageCode(globalNavigator.language)
+    : null;
+
+  if (navigatorLanguage) {
+    return navigatorLanguage;
+  }
+
+  const resolvedLocale =
+    typeof Intl !== 'undefined' ? Intl.DateTimeFormat().resolvedOptions().locale : undefined;
+
+  const intlLanguage = extractLanguageCode(resolvedLocale);
+
+  if (intlLanguage) {
+    return intlLanguage;
+  }
+
+  return fallbackLanguage;
+};
+
+const formatTranslation = (
+  key: TranslationKey,
+  language: Language,
+  params?: TranslationParams,
+): string => {
+  const template = translations[language]?.[key] ?? translations[fallbackLanguage]?.[key] ?? key;
+
+  if (!params) {
+    return template;
+  }
+
+  return template.replace(/{{(\w+)}}/g, (match, token) => {
+    const value = params[token];
+
+    return value === undefined ? match : String(value);
+  });
+};
+
+type LocalizationContextValue = {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  toggleLanguage: () => void;
+  t: (key: TranslationKey, params?: TranslationParams) => string;
+};
+
+const LocalizationContext = createContext<LocalizationContextValue | undefined>(undefined);
+
+export const LocalizationProvider = ({ children }: { children: ReactNode }) => {
+  const [language, setLanguageState] = useState<Language>(detectInitialLanguage);
+
+  const setLanguage = useCallback((nextLanguage: Language) => {
+    setLanguageState(nextLanguage);
+  }, []);
+
+  const toggleLanguage = useCallback(() => {
+    setLanguageState((current) => (current === 'en' ? 'fr' : 'en'));
+  }, []);
+
+  const translate = useCallback(
+    (key: TranslationKey, params?: TranslationParams) => formatTranslation(key, language, params),
+    [language],
+  );
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+      toggleLanguage,
+      t: translate,
+    }),
+    [language, setLanguage, toggleLanguage, translate],
+  );
+
+  return <LocalizationContext.Provider value={value}>{children}</LocalizationContext.Provider>;
+};
+
+export const useLocalization = () => {
+  const context = useContext(LocalizationContext);
+
+  if (!context) {
+    throw new Error('useLocalization must be used within a LocalizationProvider');
+  }
+
+  return context;
+};


### PR DESCRIPTION
## Summary
- introduce a localization context with English and French translations and device language detection
- update home, mode selection, and game screens plus mode and rule data to use localized copy and provide translation mapping for rules
- add a language toggle on the home screen so players can switch between French and English

## Testing
- npx tsc --noEmit *(fails: missing react-native type declarations in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c99b03daf8832d8f1a6a18b592b0db