### PR TITLE
feat: load remote config from vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,35 @@ Le workflow [`pr-preview.yml`](.github/workflows/pr-preview.yml) construit autom
 - Un commentaire est ajouté sur la PR avec les liens de téléchargement.
 
 Les secrets ne sont pas exposés aux forks ; pour les contributions externes, déclenchez les builds depuis une branche du dépôt principal.
+
+## Base de données des modes et des règles
+
+- Le script [`apps/mobile/scripts/init-vercel-db.sql`](apps/mobile/scripts/init-vercel-db.sql) crée la structure Postgres (hébergée sur Vercel) et insère les modes/règles par défaut. Appliquez-le sur une base neuve via `psql` ou le dashboard Vercel Postgres.
+- Exposez une route HTTP (par exemple `/config`) qui retourne un JSON de la forme suivante pour que l’application mobile puisse consommer les données :
+
+  ```json
+  {
+    "modes": [
+      {
+        "id": "classic",
+        "translations": {
+          "en": { "name": "Classic Rabatize", "tagline": "…", "description": "…" },
+          "fr": { "name": "Rabatize Classique", "tagline": "…", "description": "…" }
+        }
+      }
+    ],
+    "rules": [
+      {
+        "id": "toast-master",
+        "language": "en",
+        "title": "Toast Master",
+        "prompt": "{{player_1}} raises a toast…",
+        "participants": 1,
+        "modeIds": ["classic", "storyteller", "chaos"],
+        "translationMap": { "en": "toast-master", "fr": "toast-master-fr" }
+      }
+    ]
+  }
+  ```
+
+- Ajoutez la variable d’environnement `EXPO_PUBLIC_API_URL` (ex. `https://rabatize-api.vercel.app`) dans la configuration Expo afin que l’application récupère les données avant d’afficher l’interface.

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,7 +1,15 @@
+import { useEffect } from 'react';
+
+import * as SplashScreen from 'expo-splash-screen';
 import { Stack } from 'expo-router';
 
 import { GameProvider } from '@/context/GameContext';
 import { LocalizationProvider, useLocalization } from '@/context/LocalizationContext';
+import { RemoteConfigProvider, useRemoteConfig } from '@/context/RemoteConfigContext';
+
+SplashScreen.preventAutoHideAsync().catch(() => {
+  // The splash screen might already be hidden if Expo is in debug mode.
+});
 
 export const unstable_settings = {
   initialRouteName: 'index',
@@ -10,15 +18,30 @@ export const unstable_settings = {
 export default function RootLayout() {
   return (
     <LocalizationProvider>
-      <GameProvider>
-        <LocalizedStack />
-      </GameProvider>
+      <RemoteConfigProvider>
+        <GameProvider>
+          <LocalizedStack />
+        </GameProvider>
+      </RemoteConfigProvider>
     </LocalizationProvider>
   );
 }
 
 const LocalizedStack = () => {
   const { t } = useLocalization();
+  const { isReady } = useRemoteConfig();
+
+  useEffect(() => {
+    if (isReady) {
+      SplashScreen.hideAsync().catch(() => {
+        // Ignore if the splash screen was already hidden.
+      });
+    }
+  }, [isReady]);
+
+  if (!isReady) {
+    return null;
+  }
 
   return (
     <Stack>

--- a/apps/mobile/app/game.tsx
+++ b/apps/mobile/app/game.tsx
@@ -4,16 +4,21 @@ import { Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 
 import { useGame } from '@/context/GameContext';
 import { useLocalization } from '@/context/LocalizationContext';
-import { gameModes, getGameModeCopy } from '@/constants/gameModes';
+import { getGameModeCopy } from '@/constants/gameModes';
 import { compileRule, type CompiledRule } from '@/constants/rules';
+import { useRemoteConfig } from '@/context/RemoteConfigContext';
 
 const GameScreen = () => {
   const { activePlayers, selectedModeId, maxDrinks } = useGame();
   const router = useRouter();
   const { t, language } = useLocalization();
+  const { gameModes, ruleTemplates } = useRemoteConfig();
   const [currentRule, setCurrentRule] = useState<CompiledRule | null>(null);
 
-  const mode = useMemo(() => gameModes.find((item) => item.id === selectedModeId), [selectedModeId]);
+  const mode = useMemo(
+    () => gameModes.find((item) => item.id === selectedModeId),
+    [gameModes, selectedModeId],
+  );
   const modeCopy = useMemo(() => (mode ? getGameModeCopy(mode, language) : null), [language, mode]);
 
   useEffect(() => {
@@ -33,12 +38,12 @@ const GameScreen = () => {
       return;
     }
 
-    setCurrentRule(compileRule(activePlayers, maxDrinks, selectedModeId, language));
-  }, [activePlayers, language, maxDrinks, selectedModeId]);
+    setCurrentRule(compileRule(activePlayers, maxDrinks, selectedModeId, language, ruleTemplates));
+  }, [activePlayers, language, maxDrinks, ruleTemplates, selectedModeId]);
 
   const handleNextCard = () => {
     if (selectedModeId) {
-      setCurrentRule(compileRule(activePlayers, maxDrinks, selectedModeId, language));
+      setCurrentRule(compileRule(activePlayers, maxDrinks, selectedModeId, language, ruleTemplates));
     }
   };
 

--- a/apps/mobile/app/modes.tsx
+++ b/apps/mobile/app/modes.tsx
@@ -4,7 +4,8 @@ import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'rea
 
 import { useGame } from '@/context/GameContext';
 import { useLocalization } from '@/context/LocalizationContext';
-import { gameModes, getGameModeCopy } from '@/constants/gameModes';
+import { getGameModeCopy } from '@/constants/gameModes';
+import { useRemoteConfig } from '@/context/RemoteConfigContext';
 
 const ModeSelectionScreen = () => {
   const {
@@ -17,6 +18,7 @@ const ModeSelectionScreen = () => {
   } = useGame();
   const router = useRouter();
   const { t, language } = useLocalization();
+  const { gameModes } = useRemoteConfig();
   const [expandedModeId, setExpandedModeId] = useState<string | null>(selectedModeId);
 
   const canStart = Boolean(selectedModeId) && activePlayers.length >= 2;

--- a/apps/mobile/constants/gameModes.ts
+++ b/apps/mobile/constants/gameModes.ts
@@ -11,7 +11,7 @@ export type GameMode = {
   translations: Record<Language, GameModeCopy>;
 };
 
-export const gameModes: GameMode[] = [
+export const defaultGameModes: GameMode[] = [
   {
     id: 'classic',
     translations: {

--- a/apps/mobile/constants/rules.ts
+++ b/apps/mobile/constants/rules.ts
@@ -20,7 +20,7 @@ export type CompiledRule = {
   translationMap: Partial<Record<Language, string>>;
 };
 
-const ruleTemplates: RuleTemplate[] = [
+export const defaultRuleTemplates: RuleTemplate[] = [
   {
     id: 'toast-master',
     title: 'Toast Master',
@@ -199,6 +199,7 @@ export const compileRule = (
   maxDrinks: number,
   modeId: string | null,
   language: Language,
+  ruleTemplates: RuleTemplate[] = defaultRuleTemplates,
 ): CompiledRule | null => {
   if (players.length === 0) {
     return null;

--- a/apps/mobile/context/RemoteConfigContext.tsx
+++ b/apps/mobile/context/RemoteConfigContext.tsx
@@ -1,0 +1,240 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { defaultGameModes, type GameMode, type GameModeCopy } from '@/constants/gameModes';
+import {
+  defaultRuleTemplates,
+  type RuleTemplate,
+} from '@/constants/rules';
+import { fallbackLanguage, isSupportedLanguage, type Language } from '@/constants/i18n';
+
+type RemoteConfigContextValue = {
+  gameModes: GameMode[];
+  ruleTemplates: RuleTemplate[];
+  isReady: boolean;
+  isLoading: boolean;
+  error: string | null;
+  reload: () => Promise<void>;
+};
+
+const RemoteConfigContext = createContext<RemoteConfigContextValue | undefined>(undefined);
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+
+type UnknownRecord = Record<string, unknown>;
+
+type PartialGameMode = {
+  id: string;
+  translations: Partial<Record<Language, GameModeCopy>>;
+};
+
+type RemoteConfigResponse = {
+  modes: PartialGameMode[];
+  rules: RuleTemplate[];
+};
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const parseGameMode = (value: unknown): PartialGameMode | null => {
+  if (!isRecord(value) || typeof value.id !== 'string' || !isRecord(value.translations)) {
+    return null;
+  }
+
+  const translationsEntries = Object.entries(value.translations).reduce<
+    Partial<Record<Language, GameModeCopy>>
+  >((acc, [language, copy]) => {
+    if (!isSupportedLanguage(language) || !isRecord(copy)) {
+      return acc;
+    }
+
+    const { name, tagline, description } = copy;
+
+    if (
+      typeof name === 'string' &&
+      typeof tagline === 'string' &&
+      typeof description === 'string'
+    ) {
+      acc[language] = { name, tagline, description };
+    }
+
+    return acc;
+  }, {});
+
+  if (!translationsEntries[fallbackLanguage]) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    translations: translationsEntries,
+  };
+};
+
+const parseRuleTemplate = (value: unknown): RuleTemplate | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const { id, title, prompt, participants, modeIds, language, translationMap } = value;
+
+  if (
+    typeof id !== 'string' ||
+    typeof title !== 'string' ||
+    typeof prompt !== 'string' ||
+    typeof participants !== 'number' ||
+    Number.isNaN(participants) ||
+    participants <= 0 ||
+    !Array.isArray(modeIds) ||
+    modeIds.some((item) => typeof item !== 'string') ||
+    typeof language !== 'string' ||
+    !isSupportedLanguage(language)
+  ) {
+    return null;
+  }
+
+  const sanitizedTranslationMap: Partial<Record<Language, string>> = {};
+
+  if (isRecord(translationMap)) {
+    for (const [key, value] of Object.entries(translationMap)) {
+      if (isSupportedLanguage(key) && typeof value === 'string') {
+        sanitizedTranslationMap[key] = value;
+      }
+    }
+  }
+
+  return {
+    id,
+    title,
+    prompt,
+    participants: Math.max(1, Math.round(participants)),
+    modeIds: modeIds.slice(),
+    language,
+    translationMap: sanitizedTranslationMap,
+  } as RuleTemplate;
+};
+
+const sanitizeBaseUrl = (value: string) => value.replace(/\/+$/, '');
+
+const mergeWithDefaults = (remoteModes: PartialGameMode[]): GameMode[] => {
+  if (remoteModes.length === 0) {
+    return defaultGameModes;
+  }
+
+  return remoteModes.reduce<GameMode[]>((acc, mode) => {
+    const fallbackMode = defaultGameModes.find((item) => item.id === mode.id);
+    const fallbackTranslations = fallbackMode?.translations ?? ({} as Record<Language, GameModeCopy>);
+    const mergedTranslations = {
+      ...fallbackTranslations,
+      ...mode.translations,
+    } as Record<Language, GameModeCopy>;
+
+    if (!mergedTranslations[fallbackLanguage]) {
+      return acc;
+    }
+
+    acc.push({
+      id: mode.id,
+      translations: mergedTranslations,
+    });
+
+    return acc;
+  }, []);
+};
+
+const parseConfigResponse = (value: unknown): RemoteConfigResponse => {
+  if (!isRecord(value)) {
+    throw new Error('Invalid remote config payload');
+  }
+
+  const modesSource = Array.isArray(value.modes) ? value.modes : [];
+  const rulesSource = Array.isArray(value.rules) ? value.rules : [];
+
+  const modes = modesSource
+    .map(parseGameMode)
+    .filter((mode): mode is PartialGameMode => Boolean(mode));
+  const rules = rulesSource
+    .map(parseRuleTemplate)
+    .filter((rule): rule is RuleTemplate => Boolean(rule));
+
+  return { modes, rules };
+};
+
+const fetchRemoteConfig = async (): Promise<RemoteConfigResponse> => {
+  if (!API_BASE_URL) {
+    throw new Error('Missing EXPO_PUBLIC_API_URL environment variable.');
+  }
+
+  const endpoint = `${sanitizeBaseUrl(API_BASE_URL)}/config`;
+  const response = await fetch(endpoint);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load remote config (${response.status}).`);
+  }
+
+  const payload = (await response.json()) as unknown;
+  return parseConfigResponse(payload);
+};
+
+export const RemoteConfigProvider = ({ children }: { children: ReactNode }) => {
+  const [gameModes, setGameModes] = useState<GameMode[]>(defaultGameModes);
+  const [ruleTemplates, setRuleTemplates] = useState<RuleTemplate[]>(defaultRuleTemplates);
+  const [status, setStatus] = useState<'loading' | 'ready'>('loading');
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setStatus('loading');
+
+    try {
+      const { modes, rules } = await fetchRemoteConfig();
+      const mergedModes = mergeWithDefaults(modes);
+
+      setGameModes(mergedModes.length > 0 ? mergedModes : defaultGameModes);
+      setRuleTemplates(rules.length > 0 ? rules : defaultRuleTemplates);
+      setError(null);
+    } catch (err) {
+      console.error('Failed to load remote config', err);
+      setError(err instanceof Error ? err.message : 'Failed to load remote config.');
+      setGameModes(defaultGameModes);
+      setRuleTemplates(defaultRuleTemplates);
+    } finally {
+      setStatus('ready');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const value = useMemo(
+    () => ({
+      gameModes,
+      ruleTemplates,
+      isReady: status === 'ready',
+      isLoading: status !== 'ready',
+      error,
+      reload: load,
+    }),
+    [error, gameModes, load, ruleTemplates, status],
+  );
+
+  return <RemoteConfigContext.Provider value={value}>{children}</RemoteConfigContext.Provider>;
+};
+
+export const useRemoteConfig = () => {
+  const context = useContext(RemoteConfigContext);
+
+  if (!context) {
+    throw new Error('useRemoteConfig must be used within a RemoteConfigProvider');
+  }
+
+  return context;
+};
+

--- a/apps/mobile/scripts/init-vercel-db.sql
+++ b/apps/mobile/scripts/init-vercel-db.sql
@@ -1,0 +1,239 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS game_modes (
+  id TEXT PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS game_mode_translations (
+  game_mode_id TEXT NOT NULL REFERENCES game_modes(id) ON DELETE CASCADE,
+  language TEXT NOT NULL,
+  name TEXT NOT NULL,
+  tagline TEXT NOT NULL,
+  description TEXT NOT NULL,
+  PRIMARY KEY (game_mode_id, language)
+);
+
+CREATE TABLE IF NOT EXISTS rule_templates (
+  id TEXT PRIMARY KEY,
+  language TEXT NOT NULL CHECK (language IN ('en', 'fr')),
+  title TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  participants INTEGER NOT NULL CHECK (participants > 0),
+  mode_ids TEXT[] NOT NULL,
+  translation_map JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rule_templates_language ON rule_templates (language);
+CREATE INDEX IF NOT EXISTS idx_rule_templates_mode_ids ON rule_templates USING GIN (mode_ids);
+
+INSERT INTO game_modes (id) VALUES
+  ('classic'),
+  ('storyteller'),
+  ('chaos')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO game_mode_translations (game_mode_id, language, name, tagline, description) VALUES
+  (
+    'classic',
+    'en',
+    'Classic Rabatize',
+    'Balanced mix of group prompts and quick dares.',
+    'The classic experience. Expect social challenges, rhythm games, and cheers that make everyone feel part of the crew.'
+  ),
+  (
+    'classic',
+    'fr',
+    'Rabatize Classique',
+    'Mélange équilibré de défis de groupe et de gages rapides.',
+    'L’expérience classique. Attends-toi à des défis sociaux, des jeux de rythme et des toasts qui mettent tout le monde dans l’ambiance.'
+  ),
+  (
+    'storyteller',
+    'en',
+    'Storyteller',
+    'Spin tales, weave lies, and toast to the best improv.',
+    'Every card nudges the group to share a story or improvise a hilarious moment. Perfect for players who love tall tales.'
+  ),
+  (
+    'storyteller',
+    'fr',
+    'Conteur',
+    'Raconte des histoires, improvise et trinque pour la meilleure impro.',
+    'Chaque carte pousse le groupe à partager une histoire ou à improviser un moment hilarant. Parfait pour ceux qui adorent les récits.'
+  ),
+  (
+    'chaos',
+    'en',
+    'Chaos Mode',
+    'Fast-paced twists with plenty of group participation.',
+    'Expect the unexpected: sudden challenges, partner swaps, and cheers that keep everyone guessing what comes next.'
+  ),
+  (
+    'chaos',
+    'fr',
+    'Mode Chaos',
+    'Des rebondissements rapides avec beaucoup de participation.',
+    'Attends-toi à l’imprévu : défis éclairs, échanges de partenaires et toasts qui surprennent à chaque carte.'
+  )
+ON CONFLICT (game_mode_id, language)
+DO UPDATE SET
+  name = EXCLUDED.name,
+  tagline = EXCLUDED.tagline,
+  description = EXCLUDED.description;
+
+INSERT INTO rule_templates (id, language, title, prompt, participants, mode_ids, translation_map) VALUES
+  (
+    'toast-master',
+    'en',
+    'Toast Master',
+    '{{player_1}} raises a toast and gives out {{drinks}} drinks to share.',
+    1,
+    ARRAY['classic', 'storyteller', 'chaos'],
+    '{"en": "toast-master", "fr": "toast-master-fr"}'::jsonb
+  ),
+  (
+    'toast-master-fr',
+    'fr',
+    'Maître du toast',
+    '{{player_1}} porte un toast et distribue {{drinks}} gorgées à partager.',
+    1,
+    ARRAY['classic', 'storyteller', 'chaos'],
+    '{"en": "toast-master", "fr": "toast-master-fr"}'::jsonb
+  ),
+  (
+    'story-swap',
+    'en',
+    'Story Swap',
+    '{{player_1}} tells a quick tale about {{player_2}}. If {{player_2}} laughs, they hand out {{drinks}} drinks; otherwise {{player_1}} drinks them.',
+    2,
+    ARRAY['classic', 'storyteller'],
+    '{"en": "story-swap", "fr": "story-swap-fr"}'::jsonb
+  ),
+  (
+    'story-swap-fr',
+    'fr',
+    'Échange d''histoires',
+    '{{player_1}} raconte une histoire rapide sur {{player_2}}. Si {{player_2}} rit, iel distribue {{drinks}} gorgées ; sinon {{player_1}} les boit.',
+    2,
+    ARRAY['classic', 'storyteller'],
+    '{"en": "story-swap", "fr": "story-swap-fr"}'::jsonb
+  ),
+  (
+    'rabatize-chant',
+    'en',
+    'Rabatize Chant',
+    'Everyone chants "Rabatize" while {{player_1}} counts down from five. Anyone who breaks rhythm drinks {{drinks}}.',
+    1,
+    ARRAY['classic', 'chaos'],
+    '{"en": "rabatize-chant", "fr": "rabatize-chant-fr"}'::jsonb
+  ),
+  (
+    'rabatize-chant-fr',
+    'fr',
+    'Chant Rabatize',
+    'Tout le monde scande "Rabatize" pendant que {{player_1}} compte à rebours depuis cinq. Ceux qui cassent le rythme boivent {{drinks}}.',
+    1,
+    ARRAY['classic', 'chaos'],
+    '{"en": "rabatize-chant", "fr": "rabatize-chant-fr"}'::jsonb
+  ),
+  (
+    'synchronized-clap',
+    'en',
+    'Synchronized Clap',
+    '{{player_1}} and {{player_2}} perform a synchronized clap. If they miss, both drink {{drinks}}.',
+    2,
+    ARRAY['chaos'],
+    '{"en": "synchronized-clap", "fr": "synchronized-clap-fr"}'::jsonb
+  ),
+  (
+    'synchronized-clap-fr',
+    'fr',
+    'Claque synchronisée',
+    '{{player_1}} et {{player_2}} tapent dans leurs mains en même temps. S’ils ratent, les deux boivent {{drinks}}.',
+    2,
+    ARRAY['chaos'],
+    '{"en": "synchronized-clap", "fr": "synchronized-clap-fr"}'::jsonb
+  ),
+  (
+    'story-relay',
+    'en',
+    'Story Relay',
+    '{{player_1}} starts a story, {{player_2}} continues it, and {{player_3}} ends it. The trio hands out {{drinks}} drinks if the table applauds.',
+    3,
+    ARRAY['storyteller'],
+    '{"en": "story-relay", "fr": "story-relay-fr"}'::jsonb
+  ),
+  (
+    'story-relay-fr',
+    'fr',
+    'Relais d''histoires',
+    '{{player_1}} commence une histoire, {{player_2}} la continue et {{player_3}} la conclut. Le trio distribue {{drinks}} gorgées si la table applaudit.',
+    3,
+    ARRAY['storyteller'],
+    '{"en": "story-relay", "fr": "story-relay-fr"}'::jsonb
+  ),
+  (
+    'call-out',
+    'en',
+    'Call Out',
+    'Anyone who has toasted with {{player_1}} tonight drinks {{drinks}}.',
+    1,
+    ARRAY['classic', 'chaos'],
+    '{"en": "call-out", "fr": "call-out-fr"}'::jsonb
+  ),
+  (
+    'call-out-fr',
+    'fr',
+    'Appel ciblé',
+    'Tous ceux qui ont trinqué avec {{player_1}} ce soir boivent {{drinks}}.',
+    1,
+    ARRAY['classic', 'chaos'],
+    '{"en": "call-out", "fr": "call-out-fr"}'::jsonb
+  ),
+  (
+    'spotlight-word',
+    'en',
+    'Spotlight Word',
+    '{{player_1}} picks a word. Everyone tells a mini-story using it or drinks {{drinks}}.',
+    1,
+    ARRAY['storyteller', 'classic'],
+    '{"en": "spotlight-word", "fr": "spotlight-word-fr"}'::jsonb
+  ),
+  (
+    'spotlight-word-fr',
+    'fr',
+    'Mot vedette',
+    '{{player_1}} choisit un mot. Tout le monde raconte une mini-histoire qui l’utilise ou boit {{drinks}}.',
+    1,
+    ARRAY['storyteller', 'classic'],
+    '{"en": "spotlight-word", "fr": "spotlight-word-fr"}'::jsonb
+  ),
+  (
+    'seat-swap',
+    'en',
+    'Seat Swap',
+    '{{player_1}} swaps seats with {{player_2}}. The last to sit drinks {{drinks}}.',
+    2,
+    ARRAY['classic', 'chaos'],
+    '{"en": "seat-swap", "fr": "seat-swap-fr"}'::jsonb
+  ),
+  (
+    'seat-swap-fr',
+    'fr',
+    'Échange de places',
+    '{{player_1}} échange sa place avec {{player_2}}. Le dernier à s’asseoir boit {{drinks}}.',
+    2,
+    ARRAY['classic', 'chaos'],
+    '{"en": "seat-swap", "fr": "seat-swap-fr"}'::jsonb
+  )
+ON CONFLICT (id) DO UPDATE SET
+  language = EXCLUDED.language,
+  title = EXCLUDED.title,
+  prompt = EXCLUDED.prompt,
+  participants = EXCLUDED.participants,
+  mode_ids = EXCLUDED.mode_ids,
+  translation_map = EXCLUDED.translation_map;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a RemoteConfig provider that fetches modes and rules from the Vercel API before the UI appears
- gate the router behind the splash screen until remote data is loaded and update screens to consume the provider
- document and script the Postgres schema/seed used to host the remote rules and game modes

## Testing
- `npm run lint` *(fails: repository still relies on deprecated ESLint config format)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b45e778c832d89b1a027dfd968f5