### PR TITLE
feat(backoffice): add vercel-ready admin dashboard

### DIFF
--- a/.github/workflows/deploy-backoffice.yml
+++ b/.github/workflows/deploy-backoffice.yml
@@ -1,0 +1,59 @@
+name: Deploy backoffice sur Vercel
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/backoffice/**'
+      - '.github/workflows/deploy-backoffice.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Lint backoffice
+        run: npm run lint --workspace apps/backoffice
+
+      - name: Pull Vercel environment
+        working-directory: apps/backoffice
+        run: npx vercel pull --yes --environment=production --token=${{ env.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ env.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ env.VERCEL_PROJECT_ID }}
+
+      - name: Build backoffice
+        working-directory: apps/backoffice
+        run: npx vercel build --token=${{ env.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ env.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ env.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to Vercel
+        working-directory: apps/backoffice
+        run: npx vercel deploy --prebuilt --prod --token=${{ env.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ env.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ env.VERCEL_PROJECT_ID }}

--- a/apps/backoffice/README.md
+++ b/apps/backoffice/README.md
@@ -1,0 +1,46 @@
+# Backoffice Rabatize
+
+Interface Next.js déployable sur Vercel pour administrer les règles et modes de jeu de Rabatize.
+
+## Démarrage local
+
+```bash
+npm install
+npm run dev --workspace apps/backoffice
+```
+
+L’interface est accessible sur [http://localhost:3000](http://localhost:3000).
+
+## Scripts
+
+| Commande | Description |
+| --- | --- |
+| `npm run dev --workspace apps/backoffice` | Lance le serveur de développement Next.js. |
+| `npm run lint --workspace apps/backoffice` | Analyse les fichiers avec ESLint. |
+| `npm run build --workspace apps/backoffice` | Prépare le build de production. |
+| `npm run start --workspace apps/backoffice` | Démarre le serveur Next.js en mode production. |
+
+## Déploiement Vercel automatisé
+
+Le dossier contient tout le nécessaire pour un auto-déploiement sur Vercel :
+
+- `apps/backoffice/vercel.json` définit la racine du projet pour Vercel.
+- `.github/workflows/deploy-backoffice.yml` déploie automatiquement les merges sur Vercel.
+- Secrets requis côté GitHub : `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
+
+Pour initialiser le projet Vercel :
+
+```bash
+cd apps/backoffice
+npx vercel link
+```
+
+Puis configurez les secrets dans votre dépôt GitHub :
+
+```bash
+gh secret set VERCEL_TOKEN --body "<token>"
+gh secret set VERCEL_ORG_ID --body "<org-id>"
+gh secret set VERCEL_PROJECT_ID --body "<project-id>"
+```
+
+Le workflow exécute `vercel pull`, `vercel build` puis `vercel deploy --prebuilt` afin de réutiliser le build Next.js généré côté CI.

--- a/apps/backoffice/app/globals.css
+++ b/apps/backoffice/app/globals.css
@@ -1,0 +1,287 @@
+:root {
+  --background: #f5f5f5;
+  --foreground: #111827;
+  --muted: #6b7280;
+  --surface: #ffffff;
+  --border: #e5e7eb;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --success: #16a34a;
+  --warning: #d97706;
+  --danger: #dc2626;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --shadow-lg: 0 20px 25px -15px rgba(15, 23, 42, 0.35);
+  --shadow-md: 0 10px 15px -10px rgba(15, 23, 42, 0.25);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  color: var(--foreground);
+  background: linear-gradient(180deg, #eff6ff 0%, #f9fafb 60%, #f3f4f6 100%);
+  min-height: 100%;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+main {
+  min-height: 100vh;
+}
+
+.dashboard-container {
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: 48px 32px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.card-subtitle {
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.status-pill {
+  padding: 6px 12px;
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.status-pill.success {
+  background: rgba(22, 163, 74, 0.1);
+  color: var(--success);
+}
+
+.status-pill.warning {
+  background: rgba(217, 119, 6, 0.15);
+  color: var(--warning);
+}
+
+.status-pill.muted {
+  background: rgba(107, 114, 128, 0.15);
+  color: var(--muted);
+}
+
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--primary);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.section-divider {
+  height: 1px;
+  background: linear-gradient(to right, transparent, var(--border), transparent);
+  margin: 8px 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.input-group label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.input-group input,
+.input-group textarea,
+.input-group select {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  background: #f9fafb;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-group textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.input-group input:focus,
+.input-group textarea:focus,
+.input-group select:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.45);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.btn {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.btn.primary {
+  background: var(--primary);
+  color: white;
+}
+
+.btn.primary:hover {
+  background: var(--primary-hover);
+}
+
+.btn.secondary {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--primary);
+}
+
+.btn.secondary:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.btn.danger {
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--danger);
+}
+
+.btn.danger:hover {
+  background: rgba(220, 38, 38, 0.18);
+}
+
+.list-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 14px 0;
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.timeline-item time {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.metric {
+  padding: 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(37, 99, 235, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metric strong {
+  font-size: 1.6rem;
+}
+
+@media (max-width: 768px) {
+  .dashboard-container {
+    padding: 32px 20px 48px;
+  }
+
+  .timeline-item {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+}

--- a/apps/backoffice/app/layout.tsx
+++ b/apps/backoffice/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Backoffice Rabatize',
+  description:
+    'Interface d’administration pour orchestrer les règles et modes de jeux de Rabatize avec un déploiement automatisé sur Vercel.'
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <html lang="fr">
+      <body>
+        <div className="visually-hidden" id="__next-skip-link-anchor" />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/backoffice/app/page.tsx
+++ b/apps/backoffice/app/page.tsx
@@ -1,0 +1,9 @@
+import BackofficeDashboard from '@/components/BackofficeDashboard';
+
+export default function HomePage() {
+  return (
+    <main>
+      <BackofficeDashboard />
+    </main>
+  );
+}

--- a/apps/backoffice/components/BackofficeDashboard.tsx
+++ b/apps/backoffice/components/BackofficeDashboard.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  deploymentActivities,
+  initialGameModes,
+  initialRules,
+  operationalInsights
+} from '@/data/initialData';
+import { createId } from '@/lib/id';
+import type { GameMode, Rule } from '@/lib/types';
+import { formatDate, formatRelative } from '@/lib/datetime';
+import DeploymentStatusCard from './DeploymentStatusCard';
+import DeploymentTimeline from './DeploymentTimeline';
+import GameModeManager from './GameModeManager';
+import OperationalInsights from './OperationalInsights';
+import RuleManager from './RuleManager';
+
+type RulePayload = Omit<Rule, 'id' | 'lastUpdated'>;
+type GameModePayload = Omit<GameMode, 'id'>;
+
+interface StatDescriptor {
+  id: string;
+  label: string;
+  value: string;
+  detail?: string;
+}
+
+const BackofficeDashboard = () => {
+  const [rules, setRules] = useState<Rule[]>(initialRules);
+  const [gameModes, setGameModes] = useState<GameMode[]>(initialGameModes);
+
+  const sortedDeployments = useMemo(
+    () => [...deploymentActivities].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
+    []
+  );
+
+  const lastDeployment = sortedDeployments[0] ?? null;
+
+  const stats = useMemo<StatDescriptor[]>(() => {
+    const activeRules = rules.filter((rule) => rule.isActive).length;
+    const plannedModes = gameModes.filter((mode) => mode.status !== 'Archivé').length;
+
+    const nextReview = gameModes
+      .map((mode) => mode.nextReview)
+      .sort((a, b) => new Date(a).getTime() - new Date(b).getTime())[0];
+
+    const recentlyUpdatedRule = [...rules].sort(
+      (a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime()
+    )[0];
+
+    return [
+      {
+        id: 'stat-rules',
+        label: 'Règles actives',
+        value: `${activeRules}/${rules.length}`,
+        detail: activeRules === rules.length ? 'Toutes les règles sont actives' : 'Certaines règles sont en pause'
+      },
+      {
+        id: 'stat-modes',
+        label: 'Modes disponibles',
+        value: `${plannedModes}/${gameModes.length}`,
+        detail: 'Inclut les modes en production et en prévisualisation'
+      },
+      {
+        id: 'stat-review',
+        label: 'Prochaine revue',
+        value: nextReview ? formatDate(nextReview) : 'À planifier',
+        detail: nextReview ? `Dans ${formatRelative(nextReview)}` : 'Aucune revue planifiée'
+      },
+      {
+        id: 'stat-updated',
+        label: 'Dernière mise à jour',
+        value: recentlyUpdatedRule ? recentlyUpdatedRule.title : '—',
+        detail: recentlyUpdatedRule ? formatRelative(recentlyUpdatedRule.lastUpdated) : undefined
+      }
+    ];
+  }, [rules, gameModes]);
+
+  const handleRuleCreate = (payload: RulePayload) => {
+    setRules((previous) => [
+      {
+        ...payload,
+        id: createId('rule'),
+        lastUpdated: new Date().toISOString()
+      },
+      ...previous
+    ]);
+  };
+
+  const handleRuleUpdate = (id: string, payload: RulePayload) => {
+    setRules((previous) =>
+      previous.map((rule) =>
+        rule.id === id
+          ? {
+              ...rule,
+              ...payload,
+              lastUpdated: new Date().toISOString()
+            }
+          : rule
+      )
+    );
+  };
+
+  const handleRuleDelete = (id: string) => {
+    setRules((previous) => previous.filter((rule) => rule.id !== id));
+    setGameModes((previous) =>
+      previous.map((mode) => ({
+        ...mode,
+        ruleIds: mode.ruleIds.filter((ruleId) => ruleId !== id)
+      }))
+    );
+  };
+
+  const handleGameModeCreate = (payload: GameModePayload) => {
+    setGameModes((previous) => [
+      {
+        ...payload,
+        id: createId('mode')
+      },
+      ...previous
+    ]);
+  };
+
+  const handleGameModeUpdate = (id: string, payload: GameModePayload) => {
+    setGameModes((previous) => previous.map((mode) => (mode.id === id ? { ...payload, id } : mode)));
+  };
+
+  const handleGameModeDelete = (id: string) => {
+    setGameModes((previous) => previous.filter((mode) => mode.id !== id));
+  };
+
+  const previewCount = sortedDeployments.filter((deployment) => deployment.status === 'Information').length;
+  const successRate = sortedDeployments.length
+    ? Math.round(
+        (sortedDeployments.filter((deployment) => deployment.status === 'Succès').length / sortedDeployments.length) * 100
+      )
+    : 0;
+  const attentionCount = sortedDeployments.filter((deployment) => deployment.status === 'Attention').length;
+
+  return (
+    <div className="dashboard-container">
+      <section className="card" aria-labelledby="dashboard-title">
+        <div className="card-header">
+          <div>
+            <h1 id="dashboard-title" className="card-title">
+              Backoffice Rabatize
+            </h1>
+            <p className="card-subtitle">
+              Pilotez les règles de jeu, configurez les modes et suivez les déploiements Vercel en un coup d’œil.
+            </p>
+          </div>
+          <span className="status-pill success">Auto-déploiement Vercel actif</span>
+        </div>
+        <div className="section-divider" role="presentation" />
+        <p>
+          Ce tableau de bord met à disposition les leviers essentiels pour synchroniser votre design de jeu avec le pipeline
+          de livraison continue. Utilisez les sections ci-dessous pour orchestrer les règles, préparer les prochains modes et
+          déclencher les déploiements de production.
+        </p>
+      </section>
+
+      <div className="dashboard-grid" role="list" aria-label="Indicateurs clés">
+        {stats.map((stat) => (
+          <article key={stat.id} className="card" role="listitem">
+            <header className="card-header">
+              <span className="card-title">{stat.label}</span>
+            </header>
+            <strong style={{ fontSize: '2rem' }}>{stat.value}</strong>
+            {stat.detail ? <p className="card-subtitle">{stat.detail}</p> : null}
+          </article>
+        ))}
+      </div>
+
+      <div className="dashboard-grid">
+        <RuleManager rules={rules} onCreate={handleRuleCreate} onUpdate={handleRuleUpdate} onDelete={handleRuleDelete} />
+        <GameModeManager
+          rules={rules}
+          gameModes={gameModes}
+          onCreate={handleGameModeCreate}
+          onUpdate={handleGameModeUpdate}
+          onDelete={handleGameModeDelete}
+        />
+      </div>
+
+      <div className="dashboard-grid">
+        <DeploymentStatusCard
+          lastDeployment={lastDeployment}
+          previewCount={previewCount}
+          successRate={successRate}
+          attentionCount={attentionCount}
+        />
+        <OperationalInsights insights={operationalInsights} />
+        <DeploymentTimeline activities={sortedDeployments} />
+      </div>
+    </div>
+  );
+};
+
+export default BackofficeDashboard;

--- a/apps/backoffice/components/DeploymentStatusCard.tsx
+++ b/apps/backoffice/components/DeploymentStatusCard.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link';
+import type { DeploymentActivity } from '@/lib/types';
+import { formatDate, formatRelative } from '@/lib/datetime';
+
+interface DeploymentStatusCardProps {
+  lastDeployment: DeploymentActivity | null;
+  previewCount: number;
+  successRate: number;
+  attentionCount: number;
+}
+
+const DeploymentStatusCard = ({
+  lastDeployment,
+  previewCount,
+  successRate,
+  attentionCount
+}: DeploymentStatusCardProps) => {
+  return (
+    <section className="card" aria-labelledby="deployment-card-title">
+      <header className="card-header">
+        <div>
+          <h2 id="deployment-card-title" className="card-title">
+            Déploiement Vercel
+          </h2>
+          <p className="card-subtitle">
+            Synchronisez automatiquement le backoffice sur chaque merge avec les workflows GitHub préconfigurés.
+          </p>
+        </div>
+        <span className="status-pill success">Production prête</span>
+      </header>
+
+      <dl style={{ display: 'grid', gap: '12px' }}>
+        <div>
+          <dt style={{ fontWeight: 600 }}>Dernier déploiement</dt>
+          <dd>
+            {lastDeployment ? (
+              <>
+                {formatDate(lastDeployment.date)}
+                <span style={{ color: 'var(--muted)', marginLeft: 6 }}>({formatRelative(lastDeployment.date)})</span>
+              </>
+            ) : (
+              'Aucun déploiement effectué'
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt style={{ fontWeight: 600 }}>Taux de succès</dt>
+          <dd>{successRate}%</dd>
+        </div>
+        <div>
+          <dt style={{ fontWeight: 600 }}>Alerte(s) à suivre</dt>
+          <dd>{attentionCount}</dd>
+        </div>
+        <div>
+          <dt style={{ fontWeight: 600 }}>Prévisualisations générées</dt>
+          <dd>{previewCount} sur les 30 derniers jours</dd>
+        </div>
+      </dl>
+
+      <div className="section-divider" role="presentation" />
+
+      <div>
+        <h3 className="card-subtitle" style={{ fontWeight: 700, marginBottom: 8 }}>
+          Configuration résumée
+        </h3>
+        <ul style={{ margin: 0, paddingLeft: '18px', color: 'var(--muted)', display: 'grid', gap: '6px' }}>
+          <li>Racine du projet : <code>apps/backoffice</code></li>
+          <li>
+            Workflow GitHub : <code>.github/workflows/deploy-backoffice.yml</code>
+          </li>
+          <li>
+            Secrets requis : <code>VERCEL_TOKEN</code>, <code>VERCEL_ORG_ID</code>, <code>VERCEL_PROJECT_ID</code>
+          </li>
+        </ul>
+      </div>
+
+      <div className="button-row" style={{ marginTop: '12px' }}>
+        <Link
+          className="btn primary"
+          href="https://vercel.com/dashboard"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Ouvrir Vercel
+        </Link>
+        <Link
+          className="btn secondary"
+          href="https://vercel.com/docs/deployments/git"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Docs auto-déploiement
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default DeploymentStatusCard;

--- a/apps/backoffice/components/DeploymentTimeline.tsx
+++ b/apps/backoffice/components/DeploymentTimeline.tsx
@@ -1,0 +1,49 @@
+import type { DeploymentActivity } from '@/lib/types';
+import { formatDate, formatRelative } from '@/lib/datetime';
+
+interface DeploymentTimelineProps {
+  activities: DeploymentActivity[];
+}
+
+const statusTone: Record<DeploymentActivity['status'], string> = {
+  Succès: 'success',
+  Attention: 'warning',
+  Information: 'muted'
+};
+
+const DeploymentTimeline = ({ activities }: DeploymentTimelineProps) => {
+  return (
+    <section className="card" aria-labelledby="deployment-timeline-title">
+      <header className="card-header">
+        <div>
+          <h2 id="deployment-timeline-title" className="card-title">
+            Historique des déploiements
+          </h2>
+          <p className="card-subtitle">
+            Visualisez l’impact de chaque release et assurez le suivi des actions post-déploiement.
+          </p>
+        </div>
+      </header>
+
+      <div className="timeline" role="list">
+        {activities.map((activity) => (
+          <article key={activity.id} className="timeline-item" role="listitem">
+            <time dateTime={activity.date}>{formatDate(activity.date)}</time>
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <h3 style={{ margin: 0 }}>{activity.title}</h3>
+                <span className={`status-pill ${statusTone[activity.status]}`}>{activity.status}</span>
+              </div>
+              <p className="card-subtitle" style={{ marginTop: 4 }}>
+                {activity.description}
+              </p>
+              <p style={{ color: 'var(--muted)', marginTop: 8 }}>{formatRelative(activity.date)}</p>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default DeploymentTimeline;

--- a/apps/backoffice/components/GameModeManager.tsx
+++ b/apps/backoffice/components/GameModeManager.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { GameMode, DifficultyLevel, ModeStatus, Rule } from '@/lib/types';
+import { formatDate, formatRelative } from '@/lib/datetime';
+
+interface GameModeManagerProps {
+  rules: Rule[];
+  gameModes: GameMode[];
+  onCreate: (payload: Omit<GameMode, 'id'>) => void;
+  onUpdate: (id: string, payload: Omit<GameMode, 'id'>) => void;
+  onDelete: (id: string) => void;
+}
+
+interface FormState {
+  name: string;
+  description: string;
+  difficulty: DifficultyLevel;
+  status: ModeStatus;
+  rotation: GameMode['rotation'];
+  ruleIds: string[];
+  retention: number;
+  satisfaction: number;
+  completion: number;
+  nextReview: string;
+}
+
+const DIFFICULTIES: DifficultyLevel[] = ['Débutant', 'Standard', 'Expert'];
+const STATUSES: ModeStatus[] = ['Planifié', 'Actif', 'Archivé'];
+const ROTATIONS: GameMode['rotation'][] = ['Ponctuel', 'Hebdomadaire', 'Mensuel'];
+
+const today = new Date().toISOString().slice(0, 16);
+
+const EMPTY_FORM: FormState = {
+  name: '',
+  description: '',
+  difficulty: 'Standard',
+  status: 'Planifié',
+  rotation: 'Mensuel',
+  ruleIds: [],
+  retention: 75,
+  satisfaction: 4.2,
+  completion: 50,
+  nextReview: today
+};
+
+const GameModeManager = ({ rules, gameModes, onCreate, onUpdate, onDelete }: GameModeManagerProps) => {
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [editingModeId, setEditingModeId] = useState<string | null>(null);
+
+  const sortedModes = useMemo(
+    () => [...gameModes].sort((a, b) => new Date(a.nextReview).getTime() - new Date(b.nextReview).getTime()),
+    [gameModes]
+  );
+
+  const resetForm = () => {
+    setForm(EMPTY_FORM);
+    setEditingModeId(null);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const payload: Omit<GameMode, 'id'> = {
+      name: form.name.trim(),
+      description: form.description.trim(),
+      difficulty: form.difficulty,
+      status: form.status,
+      rotation: form.rotation,
+      ruleIds: form.ruleIds,
+      metrics: {
+        retention: form.retention,
+        satisfaction: form.satisfaction,
+        completion: form.completion
+      },
+      nextReview: new Date(form.nextReview).toISOString()
+    };
+
+    if (editingModeId) {
+      onUpdate(editingModeId, payload);
+    } else {
+      onCreate(payload);
+    }
+
+    resetForm();
+  };
+
+  const handleEdit = (mode: GameMode) => {
+    setEditingModeId(mode.id);
+    setForm({
+      name: mode.name,
+      description: mode.description,
+      difficulty: mode.difficulty,
+      status: mode.status,
+      rotation: mode.rotation,
+      ruleIds: mode.ruleIds,
+      retention: mode.metrics.retention,
+      satisfaction: mode.metrics.satisfaction,
+      completion: mode.metrics.completion,
+      nextReview: mode.nextReview.slice(0, 16)
+    });
+  };
+
+  return (
+    <section className="card" aria-labelledby="modes-title">
+      <header className="card-header">
+        <div>
+          <h2 id="modes-title" className="card-title">
+            Modes de jeux
+          </h2>
+          <p className="card-subtitle">
+            Planifiez vos cycles de contenu, associez les règles actives et déclenchez les prévisualisations Vercel.
+          </p>
+        </div>
+        <span className={`status-pill ${editingModeId ? 'warning' : 'success'}`}>
+          {editingModeId ? 'Édition en cours' : 'Calendrier à jour'}
+        </span>
+      </header>
+
+      <form onSubmit={handleSubmit} className="form-grid" style={{ gap: '24px' }}>
+        <div className="input-group">
+          <label htmlFor="mode-name">Nom</label>
+          <input
+            id="mode-name"
+            name="name"
+            value={form.name}
+            onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+            placeholder="Ex. Ascension tactique"
+            required
+          />
+        </div>
+        <div className="input-group">
+          <label htmlFor="mode-difficulty">Difficulté</label>
+          <select
+            id="mode-difficulty"
+            name="difficulty"
+            value={form.difficulty}
+            onChange={(event) => setForm((prev) => ({ ...prev, difficulty: event.target.value as DifficultyLevel }))}
+          >
+            {DIFFICULTIES.map((difficulty) => (
+              <option key={difficulty} value={difficulty}>
+                {difficulty}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="input-group">
+          <label htmlFor="mode-status">Statut</label>
+          <select
+            id="mode-status"
+            name="status"
+            value={form.status}
+            onChange={(event) => setForm((prev) => ({ ...prev, status: event.target.value as ModeStatus }))}
+          >
+            {STATUSES.map((status) => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="input-group">
+          <label htmlFor="mode-rotation">Rotation</label>
+          <select
+            id="mode-rotation"
+            name="rotation"
+            value={form.rotation}
+            onChange={(event) => setForm((prev) => ({ ...prev, rotation: event.target.value as GameMode['rotation'] }))}
+          >
+            {ROTATIONS.map((rotation) => (
+              <option key={rotation} value={rotation}>
+                {rotation}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+          <label htmlFor="mode-description">Description</label>
+          <textarea
+            id="mode-description"
+            name="description"
+            value={form.description}
+            onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+            placeholder="Décrivez les objectifs, récompenses et éléments différenciants."
+            required
+          />
+        </div>
+        <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+          <label htmlFor="mode-rules">Règles associées</label>
+          <select
+            id="mode-rules"
+            name="ruleIds"
+            multiple
+            value={form.ruleIds}
+            onChange={(event) =>
+              setForm((prev) => ({
+                ...prev,
+                ruleIds: Array.from(event.target.selectedOptions).map((option) => option.value)
+              }))
+            }
+          >
+            {rules.map((rule) => (
+              <option key={rule.id} value={rule.id}>
+                {rule.title}
+              </option>
+            ))}
+          </select>
+          <small style={{ color: 'var(--muted)' }}>
+            Maintenez <kbd>Ctrl</kbd> ou <kbd>Cmd</kbd> pour sélectionner plusieurs règles.
+          </small>
+        </div>
+        <div className="input-group">
+          <label htmlFor="mode-retention">Rétention (%)</label>
+          <input
+            id="mode-retention"
+            type="number"
+            name="retention"
+            min={0}
+            max={100}
+            value={form.retention}
+            onChange={(event) => setForm((prev) => ({ ...prev, retention: Number(event.target.value) }))}
+          />
+        </div>
+        <div className="input-group">
+          <label htmlFor="mode-satisfaction">Satisfaction (1-5)</label>
+          <input
+            id="mode-satisfaction"
+            type="number"
+            step="0.1"
+            min={0}
+            max={5}
+            name="satisfaction"
+            value={form.satisfaction}
+            onChange={(event) => setForm((prev) => ({ ...prev, satisfaction: Number(event.target.value) }))}
+          />
+        </div>
+        <div className="input-group">
+          <label htmlFor="mode-completion">Taux de complétion (%)</label>
+          <input
+            id="mode-completion"
+            type="number"
+            min={0}
+            max={100}
+            name="completion"
+            value={form.completion}
+            onChange={(event) => setForm((prev) => ({ ...prev, completion: Number(event.target.value) }))}
+          />
+        </div>
+        <div className="input-group">
+          <label htmlFor="mode-review">Prochaine revue</label>
+          <input
+            id="mode-review"
+            type="datetime-local"
+            name="nextReview"
+            value={form.nextReview}
+            onChange={(event) => setForm((prev) => ({ ...prev, nextReview: event.target.value }))}
+          />
+        </div>
+        <div className="button-row" style={{ gridColumn: '1 / -1' }}>
+          <button type="button" className="btn secondary" onClick={resetForm}>
+            Réinitialiser
+          </button>
+          <button type="submit" className="btn primary">
+            {editingModeId ? 'Mettre à jour le mode' : 'Créer le mode'}
+          </button>
+        </div>
+      </form>
+
+      <div className="section-divider" role="presentation" />
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+        {sortedModes.map((mode) => {
+          const associatedRules = mode.ruleIds.map((ruleId) => rules.find((rule) => rule.id === ruleId)?.title).filter(Boolean);
+
+          return (
+            <article key={mode.id}>
+              <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '12px' }}>
+                <div>
+                  <h3 style={{ margin: 0 }}>{mode.name}</h3>
+                  <p className="card-subtitle" style={{ marginTop: 4 }}>
+                    {mode.description}
+                  </p>
+                </div>
+                <span className={`status-pill ${mode.status === 'Actif' ? 'success' : mode.status === 'Planifié' ? 'warning' : 'muted'}`}>
+                  {mode.status}
+                </span>
+              </header>
+              <div className="tag-cloud" style={{ marginTop: 12 }}>
+                <span className="tag">{mode.difficulty}</span>
+                <span className="tag">Rotation : {mode.rotation}</span>
+                {associatedRules.map((ruleTitle) => (
+                  <span className="tag" key={ruleTitle}>
+                    {ruleTitle}
+                  </span>
+                ))}
+              </div>
+              <div className="metric-grid" style={{ marginTop: 12 }}>
+                <div className="metric">
+                  <span style={{ fontWeight: 600 }}>Rétention</span>
+                  <strong>{mode.metrics.retention}%</strong>
+                </div>
+                <div className="metric">
+                  <span style={{ fontWeight: 600 }}>Satisfaction</span>
+                  <strong>{mode.metrics.satisfaction}</strong>
+                </div>
+                <div className="metric">
+                  <span style={{ fontWeight: 600 }}>Complétion</span>
+                  <strong>{mode.metrics.completion}%</strong>
+                </div>
+              </div>
+              <p style={{ color: 'var(--muted)', marginTop: 8 }}>
+                Prochaine revue : {formatDate(mode.nextReview)} ({formatRelative(mode.nextReview)})
+              </p>
+              <div className="button-row" style={{ marginTop: 12 }}>
+                <button type="button" className="btn secondary" onClick={() => handleEdit(mode)}>
+                  Modifier
+                </button>
+                <button type="button" className="btn danger" onClick={() => onDelete(mode.id)}>
+                  Supprimer
+                </button>
+              </div>
+              <div className="list-divider" role="presentation" />
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default GameModeManager;

--- a/apps/backoffice/components/OperationalInsights.tsx
+++ b/apps/backoffice/components/OperationalInsights.tsx
@@ -1,0 +1,49 @@
+import type { Insight } from '@/lib/types';
+
+interface OperationalInsightsProps {
+  insights: Insight[];
+}
+
+const trendSymbol: Record<Insight['trend'], string> = {
+  up: '▲',
+  down: '▼',
+  stable: '■'
+};
+
+const trendColor: Record<Insight['trend'], string> = {
+  up: 'var(--success)',
+  down: 'var(--danger)',
+  stable: 'var(--muted)'
+};
+
+const OperationalInsights = ({ insights }: OperationalInsightsProps) => {
+  return (
+    <section className="card" aria-labelledby="insights-title">
+      <header className="card-header">
+        <div>
+          <h2 id="insights-title" className="card-title">
+            Insights opérationnels
+          </h2>
+          <p className="card-subtitle">
+            Mesurez en continu l’impact des ajustements du gameplay sur l’expérience des joueurs.
+          </p>
+        </div>
+      </header>
+
+      <div className="metric-grid">
+        {insights.map((insight) => (
+          <article key={insight.id} className="metric">
+            <span style={{ color: trendColor[insight.trend], fontSize: '1.1rem', fontWeight: 700 }}>
+              {trendSymbol[insight.trend]}
+            </span>
+            <strong>{insight.value}</strong>
+            <span style={{ fontWeight: 600 }}>{insight.label}</span>
+            <p className="card-subtitle" style={{ margin: 0 }}>{insight.description}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default OperationalInsights;

--- a/apps/backoffice/components/RuleManager.tsx
+++ b/apps/backoffice/components/RuleManager.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { Rule, RuleCategory } from '@/lib/types';
+import { formatDate } from '@/lib/datetime';
+
+interface RuleManagerProps {
+  rules: Rule[];
+  onCreate: (payload: Omit<Rule, 'id' | 'lastUpdated'>) => void;
+  onUpdate: (id: string, payload: Omit<Rule, 'id' | 'lastUpdated'>) => void;
+  onDelete: (id: string) => void;
+}
+
+const CATEGORIES: RuleCategory[] = ['Engagement', 'Progression', 'Sécurité', 'Bonus', 'Communication'];
+
+interface FormState {
+  title: string;
+  summary: string;
+  description: string;
+  category: RuleCategory;
+  tagsInput: string;
+  isActive: boolean;
+}
+
+const EMPTY_FORM: FormState = {
+  title: '',
+  summary: '',
+  description: '',
+  category: 'Engagement',
+  tagsInput: '',
+  isActive: true
+};
+
+const RuleManager = ({ rules, onCreate, onUpdate, onDelete }: RuleManagerProps) => {
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
+
+  const sortedRules = useMemo(
+    () => [...rules].sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime()),
+    [rules]
+  );
+
+  const resetForm = () => {
+    setForm(EMPTY_FORM);
+    setEditingRuleId(null);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const payload = {
+      title: form.title.trim(),
+      summary: form.summary.trim(),
+      description: form.description.trim(),
+      category: form.category,
+      tags: form.tagsInput
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+      isActive: form.isActive
+    };
+
+    if (editingRuleId) {
+      onUpdate(editingRuleId, payload);
+    } else {
+      onCreate(payload);
+    }
+
+    resetForm();
+  };
+
+  const handleEdit = (rule: Rule) => {
+    setEditingRuleId(rule.id);
+    setForm({
+      title: rule.title,
+      summary: rule.summary,
+      description: rule.description,
+      category: rule.category,
+      tagsInput: rule.tags.join(', '),
+      isActive: rule.isActive
+    });
+  };
+
+  return (
+    <section className="card" aria-labelledby="rules-title">
+      <header className="card-header">
+        <div>
+          <h2 id="rules-title" className="card-title">
+            Règles de jeu
+          </h2>
+          <p className="card-subtitle">
+            Créez, mettez à jour ou archivez les règles appliquées en production. Chaque modification déclenche une note de
+            version.
+          </p>
+        </div>
+        <span className={`status-pill ${editingRuleId ? 'warning' : 'success'}`}>
+          {editingRuleId ? 'Modification en cours' : 'Prêt à déployer'}
+        </span>
+      </header>
+
+      <form onSubmit={handleSubmit} className="form-grid" style={{ gap: '24px' }}>
+        <div className="input-group">
+          <label htmlFor="rule-title">Titre</label>
+          <input
+            id="rule-title"
+            name="title"
+            value={form.title}
+            onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+            placeholder="Ex. Progression dynamique"
+            required
+          />
+        </div>
+        <div className="input-group">
+          <label htmlFor="rule-summary">Résumé</label>
+          <input
+            id="rule-summary"
+            name="summary"
+            value={form.summary}
+            onChange={(event) => setForm((prev) => ({ ...prev, summary: event.target.value }))}
+            placeholder="Une phrase d’intention"
+            required
+          />
+        </div>
+        <div className="input-group">
+          <label htmlFor="rule-category">Catégorie</label>
+          <select
+            id="rule-category"
+            name="category"
+            value={form.category}
+            onChange={(event) => setForm((prev) => ({ ...prev, category: event.target.value as RuleCategory }))}
+          >
+            {CATEGORIES.map((category) => (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+          <label htmlFor="rule-description">Description complète</label>
+          <textarea
+            id="rule-description"
+            name="description"
+            value={form.description}
+            onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+            placeholder="Décrivez précisément le comportement attendu pour l’équipe LiveOps."
+            required
+          />
+        </div>
+        <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+          <label htmlFor="rule-tags">Tags (séparés par une virgule)</label>
+          <input
+            id="rule-tags"
+            name="tags"
+            value={form.tagsInput}
+            onChange={(event) => setForm((prev) => ({ ...prev, tagsInput: event.target.value }))}
+            placeholder="équilibrage, coopération, liveops"
+          />
+        </div>
+        <div className="input-group">
+          <label htmlFor="rule-active">Statut</label>
+          <select
+            id="rule-active"
+            name="isActive"
+            value={form.isActive ? 'active' : 'inactive'}
+            onChange={(event) => setForm((prev) => ({ ...prev, isActive: event.target.value === 'active' }))}
+          >
+            <option value="active">Active</option>
+            <option value="inactive">En pause</option>
+          </select>
+        </div>
+        <div className="button-row" style={{ gridColumn: '1 / -1' }}>
+          <button type="button" className="btn secondary" onClick={resetForm}>
+            Réinitialiser
+          </button>
+          <button type="submit" className="btn primary">
+            {editingRuleId ? 'Mettre à jour' : 'Créer la règle'}
+          </button>
+        </div>
+      </form>
+
+      <div className="section-divider" role="presentation" />
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+        {sortedRules.map((rule) => (
+          <article key={rule.id}>
+            <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '12px' }}>
+              <div>
+                <h3 style={{ margin: 0 }}>{rule.title}</h3>
+                <p className="card-subtitle" style={{ marginTop: 4 }}>
+                  {rule.summary}
+                </p>
+              </div>
+              <span className={`status-pill ${rule.isActive ? 'success' : 'warning'}`}>
+                {rule.isActive ? 'Active' : 'En pause'}
+              </span>
+            </header>
+            <p style={{ marginTop: 12 }}>{rule.description}</p>
+            <div className="tag-cloud">
+              <span className="tag">{rule.category}</span>
+              {rule.tags.map((tag) => (
+                <span className="tag" key={tag}>
+                  #{tag}
+                </span>
+              ))}
+            </div>
+            <p style={{ color: 'var(--muted)', marginTop: 8 }}>Dernière mise à jour : {formatDate(rule.lastUpdated)}</p>
+            <div className="button-row" style={{ marginTop: 12 }}>
+              <button type="button" className="btn secondary" onClick={() => handleEdit(rule)}>
+                Modifier
+              </button>
+              <button type="button" className="btn danger" onClick={() => onDelete(rule.id)}>
+                Supprimer
+              </button>
+            </div>
+            <div className="list-divider" role="presentation" />
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default RuleManager;

--- a/apps/backoffice/data/initialData.ts
+++ b/apps/backoffice/data/initialData.ts
@@ -1,0 +1,157 @@
+import type { DeploymentActivity, GameMode, Insight, Rule } from '@/lib/types';
+
+export const initialRules: Rule[] = [
+  {
+    id: 'rule-progression',
+    title: 'Progression dynamique',
+    summary: 'Ajuste automatiquement les points en fonction de la difficulté courante.',
+    description:
+      "Le barème de points est recalculé à chaque fin de partie selon la performance moyenne des joueurs pour maintenir un taux de victoire équilibré.",
+    category: 'Progression',
+    tags: ['points', 'équilibrage', 'liveops'],
+    isActive: true,
+    lastUpdated: '2024-09-18T09:15:00.000Z'
+  },
+  {
+    id: 'rule-fairplay',
+    title: 'Fair-play communautaire',
+    summary: 'Récompenses supplémentaires pour les joueurs signalant des comportements toxiques.',
+    description:
+      "Les joueurs qui envoient des signalements confirmés obtiennent un bonus temporaire de points de karma visible dans le classement social.",
+    category: 'Sécurité',
+    tags: ['modération', 'communauté'],
+    isActive: true,
+    lastUpdated: '2024-09-12T11:40:00.000Z'
+  },
+  {
+    id: 'rule-chaines',
+    title: 'Défis en chaîne',
+    summary: 'Les défis journaliers non complétés expirent après 48h.',
+    description:
+      "Chaque défi journalier se transforme en défi expert s'il n'est pas terminé sous 48 heures afin de créer un sentiment d'urgence maîtrisé.",
+    category: 'Engagement',
+    tags: ['défis', 'rétention'],
+    isActive: true,
+    lastUpdated: '2024-09-10T08:00:00.000Z'
+  },
+  {
+    id: 'rule-booster',
+    title: 'Booster collaboratif',
+    summary: 'Bonus d’expérience collectif activé lors des soirées communautaires.',
+    description:
+      "Lorsque plus de 60 % d’un salon rejoint une soirée communautaire, un multiplicateur d’expérience x1.5 est appliqué à l’ensemble du lobby.",
+    category: 'Bonus',
+    tags: ['évènement', 'coop'],
+    isActive: false,
+    lastUpdated: '2024-08-28T19:30:00.000Z'
+  }
+];
+
+export const initialGameModes: GameMode[] = [
+  {
+    id: 'mode-ascension',
+    name: 'Ascension tactique',
+    description:
+      "Mode compétitif structuré autour de paliers successifs avec révision hebdomadaire des règles actives.",
+    difficulty: 'Expert',
+    status: 'Actif',
+    rotation: 'Hebdomadaire',
+    ruleIds: ['rule-progression', 'rule-fairplay'],
+    metrics: {
+      retention: 89,
+      satisfaction: 4.3,
+      completion: 62
+    },
+    nextReview: '2024-09-25T09:00:00.000Z'
+  },
+  {
+    id: 'mode-exploration',
+    name: 'Expédition coopérative',
+    description:
+      "Sessions coopératives scénarisées avec objectifs optionnels et système de karma communautaire.",
+    difficulty: 'Standard',
+    status: 'Planifié',
+    rotation: 'Mensuel',
+    ruleIds: ['rule-fairplay', 'rule-booster'],
+    metrics: {
+      retention: 72,
+      satisfaction: 4.6,
+      completion: 48
+    },
+    nextReview: '2024-10-05T14:30:00.000Z'
+  },
+  {
+    id: 'mode-rapide',
+    name: 'Sprint éclair',
+    description:
+      "Parties rapides de 6 minutes pensées pour le mobile avec défis en chaîne et matchmaking accéléré.",
+    difficulty: 'Débutant',
+    status: 'Actif',
+    rotation: 'Ponctuel',
+    ruleIds: ['rule-chaines'],
+    metrics: {
+      retention: 65,
+      satisfaction: 4.1,
+      completion: 78
+    },
+    nextReview: '2024-09-22T17:00:00.000Z'
+  }
+];
+
+export const deploymentActivities: DeploymentActivity[] = [
+  {
+    id: 'deploy-20240918',
+    title: 'Release 2024.09.18',
+    description:
+      "Synchronisation Vercel réussie avec activation de la règle 'Progression dynamique' et audit sécurité effectué.",
+    date: '2024-09-18T18:20:00.000Z',
+    status: 'Succès'
+  },
+  {
+    id: 'deploy-20240911',
+    title: 'Préproduction 2024.09.11',
+    description:
+      "Prévisualisation générée automatiquement depuis la branche feature/modes-coop sur Vercel.",
+    date: '2024-09-11T07:35:00.000Z',
+    status: 'Information'
+  },
+  {
+    id: 'deploy-20240830',
+    title: 'Hotfix 2024.08.30',
+    description:
+      "Rollback partiel des boosters collaboratifs suite à un taux d’erreur de 2,4 % détecté après déploiement.",
+    date: '2024-08-30T22:10:00.000Z',
+    status: 'Attention'
+  }
+];
+
+export const operationalInsights: Insight[] = [
+  {
+    id: 'insight-stability',
+    label: 'Stabilité build',
+    description: 'Taux de déploiement réussi sur les 30 derniers jours.',
+    value: '96 %',
+    trend: 'up'
+  },
+  {
+    id: 'insight-feedback',
+    label: 'Feedback joueurs',
+    description: 'Note moyenne déclarée sur le dernier sondage in-game.',
+    value: '4,4 / 5',
+    trend: 'stable'
+  },
+  {
+    id: 'insight-cycle',
+    label: 'Cycle de release',
+    description: 'Durée médiane entre deux mises en production.',
+    value: '6 jours',
+    trend: 'down'
+  },
+  {
+    id: 'insight-preview',
+    label: 'Prévisualisations',
+    description: 'Builds de prévisualisation générés la semaine dernière.',
+    value: '12',
+    trend: 'up'
+  }
+];

--- a/apps/backoffice/lib/datetime.ts
+++ b/apps/backoffice/lib/datetime.ts
@@ -1,0 +1,35 @@
+export function formatDate(value: string): string {
+  const formatter = new Intl.DateTimeFormat('fr-FR', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+
+  return formatter.format(new Date(value));
+}
+
+export function formatRelative(value: string): string {
+  const now = Date.now();
+  const target = new Date(value).getTime();
+  const diff = target - now;
+
+  const thresholds: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['year', 1000 * 60 * 60 * 24 * 365],
+    ['month', (1000 * 60 * 60 * 24 * 365) / 12],
+    ['week', 1000 * 60 * 60 * 24 * 7],
+    ['day', 1000 * 60 * 60 * 24],
+    ['hour', 1000 * 60 * 60],
+    ['minute', 1000 * 60],
+    ['second', 1000]
+  ];
+
+  const rtf = new Intl.RelativeTimeFormat('fr', { numeric: 'auto' });
+
+  for (const [unit, ms] of thresholds) {
+    if (Math.abs(diff) >= ms || unit === 'second') {
+      const value = Math.round(diff / ms);
+      return rtf.format(value, unit);
+    }
+  }
+
+  return rtf.format(0, 'second');
+}

--- a/apps/backoffice/lib/id.ts
+++ b/apps/backoffice/lib/id.ts
@@ -1,0 +1,11 @@
+export function createId(prefix = 'id'): string {
+  if (
+    typeof globalThis !== 'undefined' &&
+    'crypto' in globalThis &&
+    typeof globalThis.crypto.randomUUID === 'function'
+  ) {
+    return `${prefix}-${globalThis.crypto.randomUUID()}`;
+  }
+
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/apps/backoffice/lib/types.ts
+++ b/apps/backoffice/lib/types.ts
@@ -1,0 +1,53 @@
+export type RuleCategory =
+  | 'Engagement'
+  | 'Progression'
+  | 'Sécurité'
+  | 'Bonus'
+  | 'Communication';
+
+export type DifficultyLevel = 'Débutant' | 'Standard' | 'Expert';
+
+export type ModeStatus = 'Planifié' | 'Actif' | 'Archivé';
+
+export interface Rule {
+  id: string;
+  title: string;
+  summary: string;
+  description: string;
+  category: RuleCategory;
+  tags: string[];
+  isActive: boolean;
+  lastUpdated: string;
+}
+
+export interface GameMode {
+  id: string;
+  name: string;
+  description: string;
+  difficulty: DifficultyLevel;
+  status: ModeStatus;
+  rotation: 'Ponctuel' | 'Hebdomadaire' | 'Mensuel';
+  ruleIds: string[];
+  metrics: {
+    retention: number;
+    satisfaction: number;
+    completion: number;
+  };
+  nextReview: string;
+}
+
+export interface DeploymentActivity {
+  id: string;
+  title: string;
+  description: string;
+  date: string;
+  status: 'Succès' | 'Attention' | 'Information';
+}
+
+export interface Insight {
+  id: string;
+  label: string;
+  description: string;
+  value: string;
+  trend: 'up' | 'down' | 'stable';
+}

--- a/apps/backoffice/next-env.d.ts
+++ b/apps/backoffice/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/backoffice/next.config.mjs
+++ b/apps/backoffice/next.config.mjs
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  },
+  eslint: {
+    dirs: ['app', 'components', 'data', 'lib']
+  },
+  output: 'standalone'
+};
+
+export default nextConfig;

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@rabatize/backoffice",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.4",
+    "@types/react-dom": "18.3.2"
+  }
+}

--- a/apps/backoffice/tsconfig.json
+++ b/apps/backoffice/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "alwaysStrict": true,
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "paths": {
+      "@/components/*": ["./components/*"],
+      "@/data/*": ["./data/*"],
+      "@/lib/*": ["./lib/*"]
+    },
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext",
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -1,0 +1,7 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "npm run build --workspace apps/backoffice",
+  "devCommand": "npm run dev --workspace apps/backoffice",
+  "installCommand": "npm install",
+  "outputDirectory": "apps/backoffice/.next"
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     ],
     "scripts": {
       "dev": "npm run dev --workspace apps/mobile",
+      "dev:backoffice": "npm run dev --workspace apps/backoffice",
+      "build:backoffice": "npm run build --workspace apps/backoffice",
       "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
       "format": "prettier --write .",
       "test": "jest --passWithNoTests"


### PR DESCRIPTION
## Summary
- add a Next.js backoffice application to manage gameplay rules, game modes and deployment monitoring
- seed the dashboard with initial data sets, reusable utilities and polished styling for the admin experience
- configure automated Vercel deployment via GitHub Actions and document usage plus new workspace scripts

## Testing
- `npm run lint --workspace apps/backoffice` *(fails: Next CLI missing because dependencies cannot be installed in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68c9c5b98ab8832d95b2b77efcf002e2