### PR TITLE
feat(mobile): apply neumorphic visual style

### DIFF
--- a/apps/mobile/app/game.tsx
+++ b/apps/mobile/app/game.tsx
@@ -1,3 +1,4 @@
+import { StatusBar } from 'expo-status-bar';
 import { useRouter } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
 import { Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
@@ -7,6 +8,7 @@ import { useLocalization } from '@/context/LocalizationContext';
 import { getGameModeCopy } from '@/constants/gameModes';
 import { compileRule, type CompiledRule } from '@/constants/rules';
 import { useRemoteConfig } from '@/context/RemoteConfigContext';
+import { theme } from '@/constants/theme';
 
 const GameScreen = () => {
   const { activePlayers, selectedModeId, maxDrinks } = useGame();
@@ -53,6 +55,7 @@ const GameScreen = () => {
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
       <View style={styles.container}>
         <View style={styles.header}>
           <Text style={styles.modeName}>{modeCopy?.name ?? t('home.title')}</Text>
@@ -105,7 +108,7 @@ export default GameScreen;
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#020617',
+    backgroundColor: theme.colors.background,
   },
   container: {
     flex: 1,
@@ -120,19 +123,26 @@ const styles = StyleSheet.create({
   modeName: {
     fontSize: 28,
     fontWeight: '700',
-    color: '#f8fafc',
+    color: theme.colors.textPrimary,
   },
   modeSubtitle: {
     fontSize: 14,
-    color: '#cbd5f5',
+    color: theme.colors.textSecondary,
   },
   card: {
     flex: 1,
-    borderRadius: 24,
-    backgroundColor: 'rgba(15, 23, 42, 0.85)',
-    padding: 24,
+    borderRadius: 28,
+    padding: 28,
     justifyContent: 'space-between',
-    gap: 16,
+    gap: 24,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.75)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 10, height: 10 },
+    shadowOpacity: 0.35,
+    shadowRadius: 18,
+    elevation: 10,
   },
   cardHeader: {
     flexDirection: 'row',
@@ -142,71 +152,95 @@ const styles = StyleSheet.create({
   cardTitle: {
     fontSize: 24,
     fontWeight: '700',
-    color: '#f8fafc',
+    color: theme.colors.textPrimary,
     flex: 1,
     paddingRight: 16,
   },
   cardBody: {
     fontSize: 18,
     lineHeight: 26,
-    color: '#e2e8f0',
+    color: theme.colors.textSecondary,
   },
   drinksBadge: {
-    backgroundColor: '#38bdf8',
-    borderRadius: 16,
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-    alignItems: 'center',
+    borderRadius: 18,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    backgroundColor: theme.colors.accent,
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 6,
   },
   drinksBadgeText: {
-    color: '#0f172a',
-    fontSize: 18,
+    color: '#ffffff',
+    fontSize: 20,
     fontWeight: '700',
-    lineHeight: 22,
+    lineHeight: 24,
+    textAlign: 'center',
   },
   drinksBadgeLabel: {
-    color: '#0f172a',
+    color: 'rgba(255, 255, 255, 0.85)',
     fontSize: 12,
     fontWeight: '500',
+    textAlign: 'center',
   },
   playersRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 8,
+    gap: 10,
   },
   playerChip: {
     paddingVertical: 6,
-    paddingHorizontal: 12,
-    borderRadius: 14,
-    backgroundColor: 'rgba(56, 189, 248, 0.15)',
+    paddingHorizontal: 14,
+    borderRadius: 18,
+    backgroundColor: theme.colors.backgroundAlt,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.75)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+    elevation: 4,
   },
   playerChipText: {
-    color: '#bae6fd',
+    color: theme.colors.textSecondary,
     fontWeight: '600',
   },
   actions: {
-    gap: 12,
+    gap: 14,
   },
   primaryButton: {
     paddingVertical: 18,
-    borderRadius: 18,
-    backgroundColor: '#38bdf8',
+    borderRadius: 26,
+    backgroundColor: theme.colors.accent,
     alignItems: 'center',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 10, height: 10 },
+    shadowOpacity: 0.3,
+    shadowRadius: 16,
+    elevation: 8,
   },
   primaryButtonText: {
-    color: '#0f172a',
+    color: '#ffffff',
     fontSize: 18,
     fontWeight: '700',
   },
   secondaryButton: {
     paddingVertical: 16,
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: 'rgba(148, 163, 184, 0.4)',
+    borderRadius: 24,
     alignItems: 'center',
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.7)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 6, height: 6 },
+    shadowOpacity: 0.25,
+    shadowRadius: 12,
+    elevation: 6,
   },
   secondaryButtonText: {
-    color: '#e2e8f0',
+    color: theme.colors.textSecondary,
     fontSize: 16,
     fontWeight: '600',
   },

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -15,6 +15,7 @@ import {
 
 import { useGame } from '@/context/GameContext';
 import { useLocalization } from '@/context/LocalizationContext';
+import { theme } from '@/constants/theme';
 
 const PlayerSetupScreen = () => {
   const { players, activePlayers, updatePlayer, addPlayer, removePlayer, resetMode } = useGame();
@@ -39,7 +40,7 @@ const PlayerSetupScreen = () => {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <StatusBar style="light" />
+      <StatusBar style="dark" />
       <KeyboardAvoidingView
         behavior={Platform.select({ ios: 'padding', android: undefined })}
         style={styles.flex}
@@ -69,23 +70,25 @@ const PlayerSetupScreen = () => {
               showsVerticalScrollIndicator={false}
             >
               {players.map((player, index) => (
-                <View key={`player-${index}`} style={styles.playerRow}>
-                  <TextInput
-                    value={player}
-                    onChangeText={(text) => updatePlayer(index, text)}
-                    placeholder={t('home.playerPlaceholder', { index: index + 1 })}
-                    placeholderTextColor="#777"
-                    style={styles.playerInput}
-                  />
-                  {players.length > 1 && (
-                    <Pressable
-                      accessibilityLabel={t('home.removePlayer', { index: index + 1 })}
-                      onPress={() => removePlayer(index)}
-                      style={styles.removeButton}
-                    >
-                      <Text style={styles.removeButtonText}>×</Text>
-                    </Pressable>
-                  )}
+                <View key={`player-${index}`} style={styles.playerRowWrapper}>
+                  <View style={styles.playerRow}>
+                    <TextInput
+                      value={player}
+                      onChangeText={(text) => updatePlayer(index, text)}
+                      placeholder={t('home.playerPlaceholder', { index: index + 1 })}
+                      placeholderTextColor={theme.colors.textMuted}
+                      style={styles.playerInput}
+                    />
+                    {players.length > 1 && (
+                      <Pressable
+                        accessibilityLabel={t('home.removePlayer', { index: index + 1 })}
+                        onPress={() => removePlayer(index)}
+                        style={styles.removeButton}
+                      >
+                        <Text style={styles.removeButtonText}>×</Text>
+                      </Pressable>
+                    )}
+                  </View>
                 </View>
               ))}
 
@@ -115,106 +118,143 @@ const styles = StyleSheet.create({
   flex: { flex: 1 },
   safeArea: {
     flex: 1,
-    backgroundColor: '#0f172a',
+    backgroundColor: theme.colors.background,
   },
   container: {
     flex: 1,
     paddingHorizontal: 24,
     paddingTop: 32,
     paddingBottom: 24,
+    gap: 24,
   },
   header: {
     gap: 8,
   },
   languageRow: {
     alignItems: 'flex-start',
-    marginBottom: 16,
+    marginBottom: 8,
   },
   languageToggle: {
     alignSelf: 'flex-start',
-    backgroundColor: 'rgba(148, 163, 184, 0.2)',
-    borderRadius: 16,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 18,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.75)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 4,
   },
   languageFlag: {
     fontSize: 18,
   },
   title: {
-    fontSize: 36,
+    fontSize: 34,
     fontWeight: '800',
-    color: '#f8fafc',
-    letterSpacing: 1.5,
+    color: theme.colors.textPrimary,
+    letterSpacing: 1.2,
   },
   subtitle: {
     fontSize: 16,
-    color: '#cbd5f5',
+    color: theme.colors.textSecondary,
   },
   playerSection: {
     flex: 1,
-    marginTop: 32,
-    marginBottom: 24,
+    marginBottom: 12,
   },
   playerList: {
-    gap: 12,
+    gap: 16,
     paddingBottom: 12,
+  },
+  playerRowWrapper: {
+    borderRadius: 22,
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 8, height: 8 },
+    shadowOpacity: 0.35,
+    shadowRadius: 14,
+    elevation: 6,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.7)',
   },
   playerRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: 'rgba(255, 255, 255, 0.08)',
-    borderRadius: 16,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
+    borderRadius: 22,
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+    gap: 12,
   },
   playerInput: {
     flex: 1,
-    color: '#f8fafc',
+    color: theme.colors.textPrimary,
     fontSize: 16,
   },
   removeButton: {
-    marginLeft: 12,
-    backgroundColor: 'rgba(15, 23, 42, 0.6)',
-    width: 32,
-    height: 32,
-    borderRadius: 16,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
     alignItems: 'center',
     justifyContent: 'center',
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.7)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 4,
   },
   removeButtonText: {
-    color: '#f87171',
-    fontSize: 20,
+    color: theme.colors.danger,
+    fontSize: 22,
     lineHeight: 24,
   },
   addButton: {
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: 'rgba(148, 163, 184, 0.4)',
-    paddingVertical: 14,
+    borderRadius: 22,
+    paddingVertical: 16,
     alignItems: 'center',
+    gap: 4,
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 6, height: 6 },
+    shadowOpacity: 0.35,
+    shadowRadius: 12,
+    elevation: 6,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.7)',
   },
   addButtonText: {
-    color: '#e2e8f0',
+    color: theme.colors.textSecondary,
     fontSize: 16,
     fontWeight: '600',
   },
   startButton: {
     paddingVertical: 18,
-    borderRadius: 18,
+    borderRadius: 26,
     alignItems: 'center',
-    backgroundColor: '#38bdf8',
     gap: 4,
+    backgroundColor: theme.colors.accent,
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 10, height: 10 },
+    shadowOpacity: 0.35,
+    shadowRadius: 16,
+    elevation: 8,
   },
   startButtonDisabled: {
-    backgroundColor: 'rgba(148, 163, 184, 0.4)',
+    backgroundColor: theme.colors.accentSoft,
+    shadowOpacity: 0.2,
   },
   startButtonText: {
-    color: '#0f172a',
+    color: '#ffffff',
     fontSize: 18,
     fontWeight: '700',
   },
   helperText: {
-    color: '#e2e8f0',
+    color: theme.colors.textMuted,
     fontSize: 12,
   },
 });

--- a/apps/mobile/app/modes.tsx
+++ b/apps/mobile/app/modes.tsx
@@ -1,3 +1,4 @@
+import { StatusBar } from 'expo-status-bar';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
@@ -6,6 +7,7 @@ import { useGame } from '@/context/GameContext';
 import { useLocalization } from '@/context/LocalizationContext';
 import { getGameModeCopy } from '@/constants/gameModes';
 import { useRemoteConfig } from '@/context/RemoteConfigContext';
+import { theme } from '@/constants/theme';
 
 const ModeSelectionScreen = () => {
   const {
@@ -31,6 +33,7 @@ const ModeSelectionScreen = () => {
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
       <View style={styles.container}>
         <Text style={styles.title}>{t('modes.title')}</Text>
         <Text style={styles.subtitle}>{t('modes.subtitle')}</Text>
@@ -50,7 +53,10 @@ const ModeSelectionScreen = () => {
                 }}
                 style={[styles.modeCard, selected && styles.modeCardSelected]}
               >
-                <Text style={styles.modeTitle}>{copy.name}</Text>
+                <View style={styles.modeHeader}>
+                  <Text style={styles.modeTitle}>{copy.name}</Text>
+                  {selected && <View style={styles.modePill} />}
+                </View>
                 <Text style={styles.modeTagline}>{copy.tagline}</Text>
                 {expanded && <Text style={styles.modeDescription}>{copy.description}</Text>}
               </Pressable>
@@ -64,11 +70,11 @@ const ModeSelectionScreen = () => {
             <Text style={styles.settingsSubtitle}>{t('modes.settingsSubtitle')}</Text>
           </View>
           <View style={styles.stepper}>
-            <Pressable style={styles.stepperButton} onPress={decreaseMaxDrinks}>
+            <Pressable style={[styles.stepperButton, styles.stepperButtonLeft]} onPress={decreaseMaxDrinks}>
               <Text style={styles.stepperLabel}>−</Text>
             </Pressable>
             <Text style={styles.stepperValue}>{maxDrinks}</Text>
-            <Pressable style={styles.stepperButton} onPress={increaseMaxDrinks}>
+            <Pressable style={[styles.stepperButton, styles.stepperButtonRight]} onPress={increaseMaxDrinks}>
               <Text style={styles.stepperLabel}>+</Text>
             </Pressable>
           </View>
@@ -94,23 +100,23 @@ export default ModeSelectionScreen;
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#020617',
+    backgroundColor: theme.colors.backgroundAlt,
   },
   container: {
     flex: 1,
     paddingHorizontal: 24,
     paddingTop: 32,
     paddingBottom: 24,
-    gap: 16,
+    gap: 20,
   },
   title: {
-    fontSize: 28,
+    fontSize: 30,
     fontWeight: '700',
-    color: '#f1f5f9',
+    color: theme.colors.textPrimary,
   },
   subtitle: {
     fontSize: 14,
-    color: '#cbd5f5',
+    color: theme.colors.textSecondary,
   },
   modeList: {
     flex: 1,
@@ -118,90 +124,141 @@ const styles = StyleSheet.create({
   },
   modeListContent: {
     gap: 16,
-    paddingBottom: 8,
+    paddingBottom: 16,
   },
   modeCard: {
-    borderRadius: 16,
+    borderRadius: 24,
     padding: 20,
-    backgroundColor: 'rgba(148, 163, 184, 0.1)',
-    borderWidth: 1,
-    borderColor: 'rgba(148, 163, 184, 0.25)',
     gap: 8,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.7)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 8, height: 8 },
+    shadowOpacity: 0.32,
+    shadowRadius: 14,
+    elevation: 6,
   },
   modeCardSelected: {
-    borderColor: '#38bdf8',
-    backgroundColor: 'rgba(56, 189, 248, 0.15)',
+    borderColor: theme.colors.accent,
+    shadowColor: theme.colors.accent,
+    shadowOpacity: 0.25,
   },
-  modeTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: '#f8fafc',
-  },
-  modeTagline: {
-    fontSize: 14,
-    color: '#cbd5f5',
-  },
-  modeDescription: {
-    fontSize: 13,
-    color: '#e2e8f0',
-    lineHeight: 18,
-  },
-  settingsPanel: {
-    borderRadius: 18,
-    backgroundColor: 'rgba(15, 23, 42, 0.6)',
-    padding: 20,
-    gap: 12,
-  },
-  settingsTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#f8fafc',
-  },
-  settingsSubtitle: {
-    fontSize: 13,
-    color: '#cbd5f5',
-  },
-  stepper: {
+  modeHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
   },
-  stepperButton: {
-    width: 48,
-    height: 48,
+  modePill: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: theme.colors.accent,
+    shadowColor: theme.colors.accent,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.3,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  modeTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+  },
+  modeTagline: {
+    fontSize: 14,
+    color: theme.colors.textSecondary,
+  },
+  modeDescription: {
+    fontSize: 13,
+    color: theme.colors.textMuted,
+    lineHeight: 18,
+  },
+  settingsPanel: {
     borderRadius: 24,
-    backgroundColor: '#38bdf8',
+    padding: 20,
+    gap: 16,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.7)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 8, height: 8 },
+    shadowOpacity: 0.35,
+    shadowRadius: 14,
+    elevation: 6,
+  },
+  settingsTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: theme.colors.textPrimary,
+  },
+  settingsSubtitle: {
+    fontSize: 13,
+    color: theme.colors.textSecondary,
+  },
+  stepper: {
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    gap: 12,
+  },
+  stepperButton: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.65)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 6, height: 6 },
+    shadowOpacity: 0.32,
+    shadowRadius: 12,
+    elevation: 6,
+  },
+  stepperButtonLeft: {
+    shadowOffset: { width: 6, height: 6 },
+  },
+  stepperButtonRight: {
+    shadowOffset: { width: 6, height: 6 },
   },
   stepperLabel: {
-    color: '#0f172a',
+    color: theme.colors.accent,
     fontSize: 28,
     fontWeight: '700',
     lineHeight: 32,
   },
   stepperValue: {
-    color: '#f8fafc',
-    fontSize: 20,
+    color: theme.colors.textPrimary,
+    fontSize: 22,
     fontWeight: '700',
+    width: 56,
+    textAlign: 'center',
   },
   startButton: {
     paddingVertical: 18,
-    borderRadius: 18,
+    borderRadius: 28,
     alignItems: 'center',
-    backgroundColor: '#38bdf8',
+    backgroundColor: theme.colors.accent,
     gap: 4,
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 10, height: 10 },
+    shadowOpacity: 0.3,
+    shadowRadius: 18,
+    elevation: 8,
   },
   startButtonDisabled: {
-    backgroundColor: 'rgba(148, 163, 184, 0.35)',
+    backgroundColor: theme.colors.accentSoft,
+    shadowOpacity: 0.18,
   },
   startButtonText: {
-    color: '#0f172a',
+    color: '#ffffff',
     fontSize: 18,
     fontWeight: '700',
   },
   helperText: {
-    color: '#e2e8f0',
+    color: theme.colors.textMuted,
     fontSize: 12,
     textAlign: 'center',
     paddingHorizontal: 16,

--- a/apps/mobile/constants/theme.ts
+++ b/apps/mobile/constants/theme.ts
@@ -1,0 +1,52 @@
+export const theme = {
+  colors: {
+    background: '#e8edf5',
+    backgroundAlt: '#f4f7fb',
+    surface: '#f6f9ff',
+    accent: '#7b6cff',
+    accentSoft: '#a094ff',
+    textPrimary: '#1f2937',
+    textSecondary: '#475569',
+    textMuted: '#64748b',
+    danger: '#f87171',
+    success: '#34d399',
+    shadowDark: '#b7c3dd',
+    shadowLight: '#ffffff',
+  },
+};
+
+export const neumorphicStyles = {
+  surface: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.7)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 10, height: 10 },
+    shadowOpacity: 0.4,
+    shadowRadius: 20,
+    elevation: 12,
+  },
+  concave: {
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.8)',
+    backgroundColor: theme.colors.surface,
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 6, height: 6 },
+    shadowOpacity: 0.35,
+    shadowRadius: 12,
+    elevation: 8,
+  },
+  pressable: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: 24,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.65)',
+    shadowColor: theme.colors.shadowDark,
+    shadowOffset: { width: 6, height: 6 },
+    shadowOpacity: 0.35,
+    shadowRadius: 12,
+    elevation: 8,
+  },
+};


### PR DESCRIPTION
## Summary
- introduce a shared theme palette to drive a soft, neumorphic visual language across the mobile app
- restyle the player setup experience with light backgrounds, soft shadows, and accent highlights
- refresh the mode selection and gameplay screens to match the neumorphic design, including updated controls and badges

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc0722c618832d9c79ea720f115270