### PR TITLE
feat: add tabular rules and modes views in backoffice

### DIFF
--- a/apps/backoffice/app/globals.css
+++ b/apps/backoffice/app/globals.css
@@ -30,6 +30,25 @@ body {
   min-height: 100%;
 }
 
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: -999px;
+  background: var(--primary);
+  color: white;
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  transition: transform 0.2s ease;
+}
+
+.skip-link:focus {
+  left: 16px;
+  top: 16px;
+  z-index: 20;
+  transform: scale(1.02);
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -51,8 +70,85 @@ button {
   border: 0;
 }
 
-main {
+.page-shell {
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  padding-bottom: 48px;
+}
+
+.page-footer {
+  background: rgba(15, 23, 42, 0.9);
+  color: rgba(255, 255, 255, 0.85);
+  padding: 20px 0;
+  margin-top: auto;
+}
+
+.page-footer .nav-container {
+  align-items: center;
+  gap: 12px;
+}
+
+.page-footer .nav-link.subtle {
+  color: rgba(255, 255, 255, 0.85);
+  background: transparent;
+}
+
+.page-footer .nav-link.subtle:hover {
+  color: white;
+}
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(37, 99, 235, 0.08);
+}
+
+.nav-container {
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: 16px 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.brand-link {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--primary);
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link {
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  color: var(--muted);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--foreground);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.nav-link.active {
+  background: rgba(37, 99, 235, 0.15);
+  color: var(--primary);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.2);
 }
 
 .dashboard-container {
@@ -62,6 +158,76 @@ main {
   display: flex;
   flex-direction: column;
   gap: 32px;
+}
+
+.table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.data-table th,
+.data-table td {
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  vertical-align: top;
+  text-align: left;
+}
+
+.data-table thead th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.6);
+  font-weight: 700;
+  background: rgba(37, 99, 235, 0.05);
+}
+
+.data-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.04);
+}
+
+.data-table tbody th {
+  font-size: 1rem;
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.tag-cloud.inline {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.table-primary {
+  font-weight: 600;
+}
+
+.table-secondary {
+  display: block;
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-top: 4px;
+}
+
+.metric-grid.compact {
+  grid-template-columns: repeat(3, minmax(100px, 1fr));
+  gap: 12px;
+}
+
+.metric-grid.compact .metric {
+  background: rgba(37, 99, 235, 0.08);
+  padding: 12px;
+  gap: 4px;
+}
+
+.metric-grid.compact .metric strong {
+  font-size: 1.1rem;
 }
 
 .dashboard-grid {
@@ -278,6 +444,29 @@ main {
 @media (max-width: 768px) {
   .dashboard-container {
     padding: 32px 20px 48px;
+  }
+
+  .nav-container {
+    padding: 14px 20px;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav-links {
+    width: 100%;
+  }
+
+  .nav-links li {
+    width: 100%;
+  }
+
+  .nav-link {
+    display: block;
+    width: 100%;
+  }
+
+  .data-table {
+    min-width: 640px;
   }
 
   .timeline-item {

--- a/apps/backoffice/app/layout.tsx
+++ b/apps/backoffice/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import Link from 'next/link';
+import NavigationBar from '@/components/NavigationBar';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -17,7 +19,23 @@ export default function RootLayout({
     <html lang="fr">
       <body>
         <div className="visually-hidden" id="__next-skip-link-anchor" />
-        {children}
+        <a className="skip-link" href="#main-content">
+          Aller au contenu principal
+        </a>
+        <NavigationBar />
+        <main id="main-content" className="page-shell">
+          {children}
+        </main>
+        <footer className="page-footer">
+          <div className="nav-container">
+            <p>
+              Conçu pour le backoffice Rabatize – synchronisation LiveOps &amp; Vercel.
+            </p>
+            <Link href="https://vercel.com" target="_blank" rel="noreferrer" className="nav-link subtle">
+              Infrastructure Vercel
+            </Link>
+          </div>
+        </footer>
       </body>
     </html>
   );

--- a/apps/backoffice/app/modes/page.tsx
+++ b/apps/backoffice/app/modes/page.tsx
@@ -1,0 +1,33 @@
+import GameModeTable from '@/components/GameModeTable';
+import { initialGameModes, initialRules } from '@/data/initialData';
+
+const ModesPage = () => {
+  return (
+    <div className="dashboard-container">
+      <section className="card" aria-labelledby="modes-heading">
+        <header className="card-header">
+          <div>
+            <h1 id="modes-heading" className="card-title">
+              Vue des modes de jeu
+            </h1>
+            <p className="card-subtitle">
+              Visualisez les statuts LiveOps, les règles associées et les métriques de performance par mode.
+            </p>
+          </div>
+          <span className="status-pill warning">Rotation planifiée</span>
+        </header>
+        <p>
+          Cette vue synthétise les informations opérationnelles nécessaires pour arbitrer les prochains déploiements de
+          modes. Filtrez et exportez les données depuis cette table pour aligner vos équipes design, produit et
+          infrastructure.
+        </p>
+      </section>
+
+      <section className="card" aria-label="Table des modes de jeu">
+        <GameModeTable gameModes={initialGameModes} rules={initialRules} />
+      </section>
+    </div>
+  );
+};
+
+export default ModesPage;

--- a/apps/backoffice/app/page.tsx
+++ b/apps/backoffice/app/page.tsx
@@ -1,9 +1,5 @@
 import BackofficeDashboard from '@/components/BackofficeDashboard';
 
 export default function HomePage() {
-  return (
-    <main>
-      <BackofficeDashboard />
-    </main>
-  );
+  return <BackofficeDashboard />;
 }

--- a/apps/backoffice/app/rules/page.tsx
+++ b/apps/backoffice/app/rules/page.tsx
@@ -1,0 +1,32 @@
+import RuleTable from '@/components/RuleTable';
+import { initialRules } from '@/data/initialData';
+
+const RulesPage = () => {
+  return (
+    <div className="dashboard-container">
+      <section className="card" aria-labelledby="rules-heading">
+        <header className="card-header">
+          <div>
+            <h1 id="rules-heading" className="card-title">
+              Vue des règles
+            </h1>
+            <p className="card-subtitle">
+              Analysez l’ensemble des règles actives et archivées avec leurs métadonnées clés.
+            </p>
+          </div>
+          <span className="status-pill success">Synchronisé</span>
+        </header>
+        <p>
+          Consultez les règles applicables aux différents modes de jeux ainsi que leur historique de mise à jour. Cette
+          vue tabulaire permet de préparer des exports ou de vérifier la couverture LiveOps par catégorie.
+        </p>
+      </section>
+
+      <section className="card" aria-label="Table des règles de jeu">
+        <RuleTable rules={initialRules} />
+      </section>
+    </div>
+  );
+};
+
+export default RulesPage;

--- a/apps/backoffice/components/GameModeTable.tsx
+++ b/apps/backoffice/components/GameModeTable.tsx
@@ -1,0 +1,95 @@
+import { formatDate, formatRelative } from '@/lib/datetime';
+import type { GameMode, Rule } from '@/lib/types';
+
+interface GameModeTableProps {
+  gameModes: GameMode[];
+  rules: Rule[];
+}
+
+const GameModeTable = ({ gameModes, rules }: GameModeTableProps) => {
+  const ruleMap = new Map(rules.map((rule) => [rule.id, rule.title]));
+  const sortedModes = [...gameModes].sort(
+    (a, b) => new Date(a.nextReview).getTime() - new Date(b.nextReview).getTime()
+  );
+
+  return (
+    <div className="table-wrapper" role="region" aria-live="polite">
+      <table className="data-table">
+        <caption className="visually-hidden">Modes de jeux et performances associées</caption>
+        <thead>
+          <tr>
+            <th scope="col">Mode</th>
+            <th scope="col">Difficulté</th>
+            <th scope="col">Statut</th>
+            <th scope="col">Rotation</th>
+            <th scope="col">Règles liées</th>
+            <th scope="col">Performance</th>
+            <th scope="col">Prochaine revue</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedModes.map((mode) => {
+            const associatedRules = mode.ruleIds
+              .map((ruleId) => ruleMap.get(ruleId))
+              .filter((title): title is string => Boolean(title));
+
+            return (
+              <tr key={mode.id}>
+                <th scope="row">
+                  <div className="table-primary">{mode.name}</div>
+                  <span className="table-secondary">{mode.description}</span>
+                </th>
+                <td>{mode.difficulty}</td>
+                <td>
+                  <span
+                    className={`status-pill ${
+                      mode.status === 'Actif' ? 'success' : mode.status === 'Planifié' ? 'warning' : 'muted'
+                    }`}
+                  >
+                    {mode.status}
+                  </span>
+                </td>
+                <td>{mode.rotation}</td>
+                <td>
+                  <div className="tag-cloud inline">
+                    {associatedRules.length ? (
+                      associatedRules.map((title) => (
+                        <span className="tag" key={title}>
+                          {title}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="table-secondary">Aucune règle associée</span>
+                    )}
+                  </div>
+                </td>
+                <td>
+                  <div className="metric-grid compact">
+                    <div className="metric">
+                      <span>Rétention</span>
+                      <strong>{mode.metrics.retention}%</strong>
+                    </div>
+                    <div className="metric">
+                      <span>Satisfaction</span>
+                      <strong>{mode.metrics.satisfaction}</strong>
+                    </div>
+                    <div className="metric">
+                      <span>Complétion</span>
+                      <strong>{mode.metrics.completion}%</strong>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div className="table-primary">{formatDate(mode.nextReview)}</div>
+                  <span className="table-secondary">{formatRelative(mode.nextReview)}</span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default GameModeTable;

--- a/apps/backoffice/components/NavigationBar.tsx
+++ b/apps/backoffice/components/NavigationBar.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const NAV_LINKS = [
+  { href: '/', label: 'Tableau de bord' },
+  { href: '/rules', label: 'Règles' },
+  { href: '/modes', label: 'Modes' }
+];
+
+const NavigationBar = () => {
+  const pathname = usePathname();
+
+  return (
+    <header className="top-nav">
+      <div className="nav-container">
+        <Link href="/" className="brand-link">
+          Rabatize Backoffice
+        </Link>
+        <nav aria-label="Navigation principale">
+          <ul className="nav-links">
+            {NAV_LINKS.map((link) => {
+              const isActive = pathname === link.href;
+
+              return (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className={`nav-link${isActive ? ' active' : ''}`}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default NavigationBar;

--- a/apps/backoffice/components/RuleTable.tsx
+++ b/apps/backoffice/components/RuleTable.tsx
@@ -1,0 +1,59 @@
+import { formatDate, formatRelative } from '@/lib/datetime';
+import type { Rule } from '@/lib/types';
+
+interface RuleTableProps {
+  rules: Rule[];
+}
+
+const RuleTable = ({ rules }: RuleTableProps) => {
+  const sortedRules = [...rules].sort(
+    (a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime()
+  );
+
+  return (
+    <div className="table-wrapper" role="region" aria-live="polite">
+      <table className="data-table">
+        <caption className="visually-hidden">Règles de jeu et métadonnées associées</caption>
+        <thead>
+          <tr>
+            <th scope="col">Titre</th>
+            <th scope="col">Résumé</th>
+            <th scope="col">Catégorie</th>
+            <th scope="col">Tags</th>
+            <th scope="col">Statut</th>
+            <th scope="col">Dernière mise à jour</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedRules.map((rule) => (
+            <tr key={rule.id}>
+              <th scope="row">{rule.title}</th>
+              <td>{rule.summary}</td>
+              <td>{rule.category}</td>
+              <td>
+                <div className="tag-cloud inline">
+                  {rule.tags.map((tag) => (
+                    <span className="tag" key={tag}>
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+              </td>
+              <td>
+                <span className={`status-pill ${rule.isActive ? 'success' : 'warning'}`}>
+                  {rule.isActive ? 'Active' : 'En pause'}
+                </span>
+              </td>
+              <td>
+                <div className="table-primary">{formatDate(rule.lastUpdated)}</div>
+                <span className="table-secondary">{formatRelative(rule.lastUpdated)}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default RuleTable;


### PR DESCRIPTION
## Summary
- add a navigation shell with skip link and footer to access new backoffice pages
- introduce dedicated rule and mode table components and route-level views
- extend global styling to support navigation and tabular layouts

## Testing
- npm run lint *(fails: Next.js tries to auto-install TypeScript via Yarn and aborts with an ERR_UNHANDLED_REJECTION)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1683c194832da6c5c660abf2b47b